### PR TITLE
Remove verifier from lcm cli

### DIFF
--- a/tools/lcm_cli/CMakeLists.txt
+++ b/tools/lcm_cli/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(${JBPF_LCM_IPC_CLI} PUBLIC ${JBPF_LCM_HEADER_FILES}
                                                         ${HEADER_FILES}
                                                         ${JBPF_LCM_IPC_CLI_HEADER_FILES}
                                                         ${JBPF_VERIFIER_HEADERS})
-target_link_libraries(${JBPF_LCM_IPC_CLI} PUBLIC jbpf::core_lib jbpf::verifier_lib ${YAML_CPP_LIBRARIES} jbpf::lcm_ipc_lib)
+target_link_libraries(${JBPF_LCM_IPC_CLI} PUBLIC jbpf::core_lib ${YAML_CPP_LIBRARIES} jbpf::lcm_ipc_lib)
 
 set_target_properties(${JBPF_LCM_IPC_CLI}
     PROPERTIES

--- a/tools/lcm_cli/parser.cpp
+++ b/tools/lcm_cli/parser.cpp
@@ -7,7 +7,6 @@
 #include <iomanip>
 #include <regex>
 #include "stream_id.hpp"
-#include "jbpf_verifier.hpp"
 
 namespace jbpf_lcm_cli {
 namespace parser {
@@ -140,12 +139,6 @@ parse_jbpf_codelet_descriptor(YAML::Node cfg, jbpf_codelet_descriptor_s* dest, v
     }
     codelet_path.copy(dest->codelet_path, JBPF_PATH_LEN - 1);
     dest->codelet_path[codelet_path.length()] = '\0';
-
-    auto result = jbpf_verify(codelet_path.c_str(), nullptr, nullptr);
-    if (!result.verification_pass) {
-        cout << "Codelet verification failed: " << result.err_msg << endl;
-        return JBPF_LCM_PARSE_VERIFIER_FAILED;
-    }
 
     if (cfg["priority"].IsDefined()) {
         auto priority = cfg["priority"].as<uint32_t>();


### PR DESCRIPTION
The expectation is that external integrations will extend the verifier themselves for a given context. This will lead to the default verifier check failing when loading the codelets which depend on the external context. 