### PR TITLE
IPC example bugfix

### DIFF
--- a/examples/first_example_ipc/example_collect_control.cpp
+++ b/examples/first_example_ipc/example_collect_control.cpp
@@ -70,9 +70,9 @@ handle_channel_bufs(
             // Send an acknowledgement message back to the codelet using IPC API
             PacketResp resp = {p.seq_no};
             jbpf_io_channel_send_msg(io_ctx, &control_input_stream_id, &resp, sizeof(resp));
-        
-	    jbpf_io_channel_release_buf(bufs[i]);
-	}
+
+            jbpf_io_channel_release_buf(bufs[i]);
+        }
     }
 }
 

--- a/examples/first_example_ipc/example_collect_control.cpp
+++ b/examples/first_example_ipc/example_collect_control.cpp
@@ -70,7 +70,9 @@ handle_channel_bufs(
             // Send an acknowledgement message back to the codelet using IPC API
             PacketResp resp = {p.seq_no};
             jbpf_io_channel_send_msg(io_ctx, &control_input_stream_id, &resp, sizeof(resp));
-        }
+        
+	    jbpf_io_channel_release_buf(bufs[i]);
+	}
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug in the IPC example, where the buffers received by the collector were not released properly, leading to all messages being dropped after a while.