### PR TITLE
Expose jbpf::reverse_proxy_lib to higher layer CMake systems

### DIFF
--- a/examples/reverse_proxy/CMakeLists.txt
+++ b/examples/reverse_proxy/CMakeLists.txt
@@ -69,3 +69,4 @@ set_target_properties(${BINARY_NAME}
 # Link the static library and additional libraries with the executable
 target_link_libraries(${BINARY_NAME} ${LIBRARY_NAME} ${LINK_LIBS} ${LINK_FLAGS})
 
+add_library(jbpf::reverse_proxy_lib ALIAS ${LIBRARY_NAME})


### PR DESCRIPTION
Add a line so that the reverse_proxy library is exposed to high layer Cmake systems.