### PR TITLE
Bug fix for reference counting of mbufs and API name change

### DIFF
--- a/src/io/jbpf_io_channel.c
+++ b/src/io/jbpf_io_channel.c
@@ -793,16 +793,17 @@ jbpf_io_channel_recv_data_copy(struct jbpf_io_channel* channel, void* buf, size_
     return 1;
 }
 
-void*
+jbpf_channel_buf_ptr
 jbpf_io_channel_share_data_ptr(jbpf_channel_buf_ptr data_ptr)
 {
+    jbpf_io_channel_elem_t* elem;
 
-    void* data;
-
-    if (!data_ptr)
+    if (!data_ptr) {
         return NULL;
+    }
 
-    data = container_of(data_ptr, jbpf_io_channel_elem_t, data);
+    elem = container_of(data_ptr, jbpf_io_channel_elem_t, data);
+    jbpf_mbuf_share_data_ptr(elem);
 
-    return jbpf_mbuf_share(data);
+    return elem->data;
 }

--- a/src/io/jbpf_io_channel.h
+++ b/src/io/jbpf_io_channel.h
@@ -193,11 +193,11 @@ extern "C"
      * @brief Increments the reference counter of a reserved data pointer of a channel.
      *
      * @param data_ptr The reserved data pointer.
-     * @return void* A pointer to the same buffer, with the reference count incremented by one.
+     * @return jbpf_channel_buf_ptr A pointer to the same buffer, with the reference count incremented by one.
      * @ingroup io
      */
-    void*
-    jbpf_mbuf_share_data_ptr(jbpf_channel_buf_ptr data_ptr);
+    jbpf_channel_buf_ptr
+    jbpf_io_channel_share_data_ptr(jbpf_channel_buf_ptr data_ptr);
 
 #ifdef __cplusplus
 }

--- a/src/mem_mgmt/jbpf_mem_mgmt_utils.h
+++ b/src/mem_mgmt/jbpf_mem_mgmt_utils.h
@@ -3,6 +3,12 @@
 
 #include <stddef.h>
 
+#define container_of(ptr, type, member)                   \
+    ({                                                    \
+        const typeof(((type*)0)->member)* __mptr = (ptr); \
+        (type*)((char*)__mptr - offsetof(type, member));  \
+    })
+
 #define round_up_pow_of_two(x) \
     ({                         \
         uint32_t v = x;        \

--- a/src/mem_mgmt/jbpf_mempool.c
+++ b/src/mem_mgmt/jbpf_mempool.c
@@ -251,7 +251,7 @@ jbpf_mbuf_share_data_ptr(void* data_ptr)
     if (!data_ptr)
         return NULL;
 
-    struct jbpf_mbuf* mb = (struct jbpf_mbuf*)((uint8_t*)data_ptr - offsetof(struct jbpf_mbuf, data));
+    struct jbpf_mbuf* mb = container_of(data_ptr, struct jbpf_mbuf, data);
     atomic_fetch_add(&mb->ref_cnt, 1);
     return data_ptr;
 }


### PR DESCRIPTION
This PR fixes a bug that resulted in corrupting jmbufs every time a buffer pointer was shared using the `jbpf_mbuf_share_data_ptr()` API call.  It also changes the public API name of the function from` jbpf_mbuf_share_data_ptr()` to `jbpf_io_channel_share_data_ptr()`.