### PR TITLE
Remove misleading LCM_PATH

### DIFF
--- a/src/core/jbpf_config.h
+++ b/src/core/jbpf_config.h
@@ -35,13 +35,13 @@
 /**
  * @brief JBPF agent lcm IPC configuration
  * @param has_lcm_ipc_thread Whether to use LCM IPC thread
- * @param lcm_ipc_path The path to the LCM IPC socket
+ * @param lcm_ipc_name The name of the LCM IPC socket
  * @ingroup core
  */
 struct jbpf_agent_lcm_ipc_config
 {
     bool has_lcm_ipc_thread;
-    char lcm_ipc_name[JBPF_LCM_IPC_PATH_LEN];
+    char lcm_ipc_name[JBPF_LCM_IPC_NAME_LEN];
 };
 
 /**

--- a/src/lcm/jbpf_lcm_ipc.h
+++ b/src/lcm/jbpf_lcm_ipc.h
@@ -9,9 +9,8 @@ extern "C"
 {
 #endif
 
-#define JBPF_LCM_IPC_PATH_LEN (512U)
+#define JBPF_LCM_IPC_NAME_LEN (512U)
 #define JBPF_LCM_IPC_ADDRESS_LEN (1024U)
-#define JBPF_LCM_IPC_NAME_LEN (64U)
 #define JBPF_LCM_IPC_REQ_BACKLOG (40U)
 #define JBPF_DEFAULT_LCM_SOCKET "jbpf_lcm_ipc"
 

--- a/tools/lcm_cli/loader.cpp
+++ b/tools/lcm_cli/loader.cpp
@@ -110,7 +110,7 @@ parseArgs(int ac, char** av, lcm_cli_config* opts)
         break;
     }
 
-    address.copy(opts->addr.path, JBPF_LCM_IPC_PATH_LEN - 1);
+    address.copy(opts->addr.path, JBPF_LCM_IPC_NAME_LEN - 1);
     opts->addr.path[address.length()] = '\0';
 
     if (!exists(filename)) {


### PR DESCRIPTION
This PR removes the misleading lcm_ipc_path given that we already have lcm_ipc_name. 