### PR TITLE
Add INITIALIZE_SUBMODULES opt to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,17 +40,18 @@ set(VERSION_FILE ${PROJECT_SOURCE_DIR}/VERSION)
 set(VERSION_HEADER ${JBPF_SOURCE_CODE}/common/jbpf_version.h)
 
 # Execute the setup script first
-execute_process(
-    COMMAND ./init_and_patch_submodules.sh
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    RESULT_VARIABLE result
-    OUTPUT_VARIABLE output
-    ERROR_VARIABLE error
-)
-
-# Check if the script ran successfully
-if(NOT result EQUAL 0)
-    message(FATAL_ERROR "Setup script failed with error: ${error}")
+option(INITIALIZE_SUBMODULES "Initialize submodules" ON)
+if(INITIALIZE_SUBMODULES)
+    execute_process(
+        COMMAND ./init_and_patch_submodules.sh
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+    if(NOT result EQUAL 0)
+        message(FATAL_ERROR "Setup script failed with error: ${error}")
+    endif()
 endif()
 
 ################ Definitions ################


### PR DESCRIPTION
By default, the script `./init_and_patch_submodules.sh` will run as part of cmake.

If you want to build jbpf without running the script you can run: `cmake -DINITIALIZE_SUBMODULES=off ../ && make -j` to skip this step in the cmake.

One reason you might want to do this would be that you are building inside a container which does not have `git` installed. You may choose to load the submodules externally before building inside the container.