### PR TITLE
Implement the send_all and recv_all

### DIFF
--- a/src/io/jbpf_io_ipc.c
+++ b/src/io/jbpf_io_ipc.c
@@ -1170,15 +1170,23 @@ jbpf_io_ipc_register(struct jbpf_io_ipc_cfg* dipc_cfg, struct jbpf_io_ctx* io_ct
         }
         ipc_neg_req.msg_type = JBPF_IO_IPC_REG_REQ;
         jbpf_logger(JBPF_INFO, "Sending notification\n");
-        if (send(ipc_desc->sock_fd, &ipc_neg_req, sizeof(struct jbpf_io_ipc_msg), 0) !=
-            sizeof(struct jbpf_io_ipc_msg)) {
+        int send_res = send(ipc_desc->sock_fd, &ipc_neg_req, sizeof(struct jbpf_io_ipc_msg), 0);
+        if (send_res != sizeof(struct jbpf_io_ipc_msg)) {
+            jbpf_logger(
+                JBPF_ERROR, "Error while sending notification %d: %d\n", send_res, (int)sizeof(struct jbpf_io_ipc_msg));
             goto sock_close;
         }
 
         jbpf_logger(JBPF_INFO, "Waiting for peer update\n");
-        if (recv(ipc_desc->sock_fd, &ipc_reg_resp, sizeof(struct jbpf_io_ipc_msg), MSG_WAITALL) !=
-            sizeof(struct jbpf_io_ipc_msg))
+        int recv_res = recv(ipc_desc->sock_fd, &ipc_reg_resp, sizeof(struct jbpf_io_ipc_msg), MSG_WAITALL);
+        if (recv_res != sizeof(struct jbpf_io_ipc_msg)) {
+            jbpf_logger(
+                JBPF_ERROR,
+                "Error while receiving notification %d: %d\n",
+                recv_res,
+                (int)sizeof(struct jbpf_io_ipc_msg));
             goto sock_close;
+        }
 
         jbpf_logger(JBPF_INFO, "Received peer update with status %d\n", ipc_reg_resp.msg.dipc_reg_resp.status);
 

--- a/src/io/jbpf_io_ipc.c
+++ b/src/io/jbpf_io_ipc.c
@@ -1073,7 +1073,17 @@ send_all(int sock_fd, const void* buf, size_t len, int flags)
     size_t total = 0;
     ssize_t bytes_left = len;
     ssize_t n;
-
+    if (len == 0) {
+        return 0;
+    }
+    if (buf == NULL) {
+        jbpf_logger(JBPF_ERROR, "Buffer is NULL\n");
+        return -1;
+    }
+    if (sock_fd < 0) {
+        jbpf_logger(JBPF_ERROR, "Socket fd is invalid\n");
+        return -1;
+    }
     while (total < len) {
         n = send(sock_fd, buf + total, bytes_left, flags);
         if (n == -1) {
@@ -1092,17 +1102,30 @@ recv_all(int sock_fd, void* buf, size_t len, int flags)
     size_t total = 0;
     ssize_t bytes_left = len;
     ssize_t n;
-
+    if (len == 0) {
+        return 0;
+    }
+    if (buf == NULL) {
+        jbpf_logger(JBPF_ERROR, "Buffer is NULL\n");
+        return -1;
+    }
+    if (sock_fd < 0) {
+        jbpf_logger(JBPF_ERROR, "Socket fd is invalid\n");
+        return -1;
+    }
     while (total < len) {
         n = recv(sock_fd, buf + total, bytes_left, flags);
         if (n == -1) {
             break;
         }
+        if (n == 0) {
+            // Connection closed
+            break;
+        }
         total += n;
         bytes_left -= n;
     }
-
-    return (n == -1) ? -1 : total;
+    return bytes_left == 0 ? total : -1;
 }
 
 int


### PR DESCRIPTION
For large data transfers, reliable delivery, and error handling, it's a good practice to implement send_all() to handle partial sends and retries, even when you're in blocking mode. Same for recv_all().