### PR TITLE
Fix tests under RELEASE build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,9 @@ elseif(CMAKE_BUILD_TYPE MATCHES Debug)
   add_compile_options(--coverage -g)
   add_link_options(--coverage)
 else()
+  ## fallback to release mode
+  set(CMAKE_BUILD_TYPE Release)
+  message(STATUS "CMAKE_BUILD_TYPE not set, defaulting to Release")
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
 endif()
 

--- a/jbpf_tests/common/jbpf_test_lib.h
+++ b/jbpf_tests/common/jbpf_test_lib.h
@@ -37,4 +37,13 @@ jbpf_run_test(
 #define JBPF_CREATE_TEST(test_func, setup_func, teardown_func, initial_state) \
     __jbpf_create_test(test_func, setup_func, teardown_func, initial_state, #test_func)
 
+// Macro to assert and avoid unused variable warnings when assert is optimised out
+// in release builds. This is a workaround for the fact that assert is a no-op in
+#define __assert__(condition) \
+    do { \
+        int __assert_result = (int)(condition); \
+        assert(__assert_result); \
+        (void)__assert_result; \
+    } while (0)
+
 #endif // JBPF_TEST_LIB_H

--- a/jbpf_tests/concurrency/atomic/atomic_concurrency_test.c
+++ b/jbpf_tests/concurrency/atomic/atomic_concurrency_test.c
@@ -22,6 +22,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define HOOK_CALLED_TIME (10000)
 #define NUMBER_OF_WORKERS (8)
@@ -69,7 +70,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -90,7 +91,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -101,7 +102,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test0");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     struct thread_params data;
     memset(&data, 0, sizeof(data));
@@ -136,7 +137,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/concurrency/control_input/codelet_control_input_concurrency_atomic_test.c
+++ b/jbpf_tests/concurrency/control_input/codelet_control_input_concurrency_atomic_test.c
@@ -17,6 +17,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define CONTROL_CALLED_COUNT 1000
 #define HOOK_CALLED_COUNT 10000
@@ -92,7 +93,7 @@ main(int argc, char** argv)
     // The input channel of the codelet does not have a serializer
     codeletset_req.codelet_descriptor[0].out_io_channel[0].has_serde = false;
 
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -101,13 +102,13 @@ main(int argc, char** argv)
     strcpy(codeletset_req.codelet_descriptor[0].codelet_name, "simple_input_output_atomic");
     strcpy(codeletset_req.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     pthread_barrier_init(&barrier_control, NULL, NUM_THREADS_CONTROL);
     pthread_t control_threads[NUM_THREADS_CONTROL];
@@ -157,7 +158,7 @@ main(int argc, char** argv)
 
     // Unload the codeletset
     strcpy(codeletset_unload_req.codeletset_id.name, "simple_input_output_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // free
     for (int i = 0; i < NUM_THREADS_CONTROL; i++) {

--- a/jbpf_tests/concurrency/control_input/codelet_control_input_concurrency_test.c
+++ b/jbpf_tests/concurrency/control_input/codelet_control_input_concurrency_test.c
@@ -18,6 +18,7 @@ is received exactly once.
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define COUNT 1000
 #define NUM_THREADS_CONTROL 4
@@ -115,7 +116,7 @@ main(int argc, char** argv)
     // The input channel of the codelet does not have a serializer
     codeletset_req.codelet_descriptor[0].out_io_channel[0].has_serde = false;
 
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -124,7 +125,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req.codelet_descriptor[0].codelet_name, "simple_input_output");
     strcpy(codeletset_req.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -135,7 +136,7 @@ main(int argc, char** argv)
     sem_init(&sem, 0, 0);
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     pthread_t control_threads[NUM_THREADS_CONTROL];
     struct thread_params** params = malloc(NUM_THREADS_CONTROL * sizeof(struct thread_params*));
@@ -164,7 +165,7 @@ main(int argc, char** argv)
 
     // Unload the codeletset
     strcpy(codeletset_unload_req.codeletset_id.name, "simple_input_output_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     sem_destroy(&sem);
 

--- a/jbpf_tests/concurrency/hashmap/codelet_hashmap_concurrency_read_test.c
+++ b/jbpf_tests/concurrency/hashmap/codelet_hashmap_concurrency_read_test.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define HOOK_CALLED_TIME (100)
 #define NUMBER_OF_WORKERS (20)
@@ -63,7 +64,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -84,7 +85,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -95,7 +96,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     struct thread_params* data[NUMBER_OF_WORKERS];
     for (int i = 0; i < NUMBER_OF_WORKERS; ++i) {
@@ -135,7 +136,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/concurrency/hashmap/codelet_per_hashmap_array_concurrency_test.c
+++ b/jbpf_tests/concurrency/hashmap/codelet_per_hashmap_array_concurrency_test.c
@@ -13,6 +13,7 @@ The test will check if the counter_a and counter_b are incremented correctly.
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define HOOK_CALLED_TIME (10000)
 #define NUMBER_OF_WORKERS (4)
@@ -60,7 +61,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -82,7 +83,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -93,7 +94,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     struct thread_params* data[NUMBER_OF_WORKERS];
     for (int i = 0; i < NUMBER_OF_WORKERS; ++i) {
@@ -127,7 +128,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/concurrency/hooks/concurrent_hook_execution_unload_test.c
+++ b/jbpf_tests/concurrency/hooks/concurrent_hook_execution_unload_test.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define HOOK_CALLED_TIME (100000)
 #define NUMBER_OF_WORKERS (5)
@@ -89,7 +90,7 @@ load_codeletset(jbpf_io_stream_id_t stream_id, const char* codelet_set_name, con
 
     // The path of the codelet
     const char* jbpf_path = getenv("JBPF_PATH");
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -100,7 +101,7 @@ load_codeletset(jbpf_io_stream_id_t stream_id, const char* codelet_set_name, con
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, hook_name);
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 }
 
 #define DEFINE_THREAD_LOAD_FUNC(NAME, STREAM_ID, CODDELETSET_NAME, HOOK_NAME) \
@@ -127,7 +128,7 @@ unload_func(jbpf_codeletset_id_t codeletset_id)
     struct jbpf_codeletset_unload_req codeletset_unload_req_c1 = {0};
 
     codeletset_unload_req_c1.codeletset_id = codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 }
 
 #define DEFINE_THREAD_UNLOAD_FUNC(NAME, CODELET_SET_ID)             \
@@ -162,7 +163,7 @@ main(int argc, char** argv)
     struct jbpf_config config = {0};
     jbpf_set_default_config_options(&config);
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
     jbpf_register_thread();
 
     for (int iter = 0; iter < ITERATIONS; ++iter) {

--- a/jbpf_tests/concurrency/ringbuf/codelet_ringbuf_concurrency_test.c
+++ b/jbpf_tests/concurrency/ringbuf/codelet_ringbuf_concurrency_test.c
@@ -15,6 +15,7 @@ failures).
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define HOOK_CALLED_TIME (2500)
 #define NUMBER_OF_WORKERS (4)
@@ -62,7 +63,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -87,7 +88,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -98,7 +99,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     struct thread_params* data[NUMBER_OF_WORKERS];
     for (int i = 0; i < NUMBER_OF_WORKERS; ++i) {
@@ -129,7 +130,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/e2e_examples/jbpf_e2e_ipc_test.c
+++ b/jbpf_tests/e2e_examples/jbpf_e2e_ipc_test.c
@@ -22,6 +22,7 @@
 #include "jbpf_io_defs.h"
 #include "jbpf_io_queue.h"
 #include "jbpf_io_channel.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 
@@ -119,7 +120,7 @@ run_primary_process(void)
 
     assert(io_ctx);
 
-    assert(jbpf_io_register_thread());
+    __assert__(jbpf_io_register_thread());
 
     // Primary is initialized. Signal secondary and
     // wait until codelets are loaded
@@ -130,7 +131,7 @@ run_primary_process(void)
     for (int i = 0; i < NUM_ITERATIONS; i++) {
         custom_api control_input = {.command = i + 100};
         JBPF_UNUSED(control_input);
-        assert(jbpf_io_channel_send_msg(io_ctx, &stream_id_c2, &control_input, sizeof(control_input)) == 0);
+        __assert__(jbpf_io_channel_send_msg(io_ctx, &stream_id_c2, &control_input, sizeof(control_input)) == 0);
     }
 
     // Wait until the secondary has finished with its responses
@@ -170,7 +171,7 @@ run_jbpf_agent(void)
     // Primary is ready, so let's initialize the agent
     sem_wait(primary_sem);
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     jbpf_register_thread();
 
@@ -195,7 +196,7 @@ run_jbpf_agent(void)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -205,7 +206,7 @@ run_jbpf_agent(void)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Next, we load the codeletset with codelets C2 and C3 in hooks "test1" and "test2"
     strcpy(codeletset_req_c2_c3.codeletset_id.name, "shared_map_input_output_codeletset");
@@ -223,7 +224,7 @@ run_jbpf_agent(void)
     // The input channel of the codelet does not have a serializer
     codeletset_req_c2_c3.codelet_descriptor[0].in_io_channel[0].has_serde = false;
 
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c2_c3.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -247,7 +248,7 @@ run_jbpf_agent(void)
     // The name of the linked map as it appears in C2
     strcpy(codeletset_req_c2_c3.codelet_descriptor[1].linked_maps[0].linked_map_name, "shared_map");
 
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c2_c3.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -257,7 +258,7 @@ run_jbpf_agent(void)
     strcpy(codeletset_req_c2_c3.codelet_descriptor[1].hook_name, "test2");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c2_c3, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c2_c3, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Wait until the primary sends the inputs
     sem_post(secondary_sem);
@@ -281,10 +282,10 @@ run_jbpf_agent(void)
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "simple_output_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     strcpy(codeletset_unload_req_c2_c3.codeletset_id.name, "shared_map_input_output_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c2_c3, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c2_c3, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/e2e_examples/jbpf_e2e_lcm_ipc_standalone_test.c
+++ b/jbpf_tests/e2e_examples/jbpf_e2e_lcm_ipc_standalone_test.c
@@ -19,6 +19,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 
@@ -86,7 +87,7 @@ run_jbpf_agent(void)
     jbpf_set_default_config_options(&config);
     sem_init(&sem, 0, 0);
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -165,7 +166,7 @@ run_lcm_ipc_loader(void)
     codeletset_req_c1.codelet_descriptor[0].out_io_channel[0].has_serde = false;
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -175,7 +176,7 @@ run_lcm_ipc_loader(void)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Make a request to load the codeletset
-    assert(jbpf_lcm_ipc_send_codeletset_load_req(&address, &codeletset_req_c1) == JBPF_LCM_IPC_REQ_SUCCESS);
+    __assert__(jbpf_lcm_ipc_send_codeletset_load_req(&address, &codeletset_req_c1) == JBPF_LCM_IPC_REQ_SUCCESS);
 
     // Loading was done, so the agent test can move on
     sem_post(lcm_ipc_agent_sem);
@@ -187,17 +188,17 @@ run_lcm_ipc_loader(void)
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "simple_output_codeletset");
 
     // Make a request to unload an existing codeletset
-    assert(jbpf_lcm_ipc_send_codeletset_unload_req(&address, &codeletset_unload_req_c1) == JBPF_LCM_IPC_REQ_SUCCESS);
+    __assert__(jbpf_lcm_ipc_send_codeletset_unload_req(&address, &codeletset_unload_req_c1) == JBPF_LCM_IPC_REQ_SUCCESS);
 
     // Make a request to load a codeletset that will fail, due to non-existent hook
     strcpy(codeletset_req_error.codeletset_id.name, "error_codeletset");
     codeletset_req_error.num_codelet_descriptors = 1;
     strcpy(codeletset_req_error.codelet_descriptor[0].hook_name, "hook404");
-    assert(jbpf_lcm_ipc_send_codeletset_load_req(&address, &codeletset_req_error) == JBPF_LCM_IPC_REQ_FAIL);
+    __assert__(jbpf_lcm_ipc_send_codeletset_load_req(&address, &codeletset_req_error) == JBPF_LCM_IPC_REQ_FAIL);
 
     // Make a request to unload a non-existent codeletset
     strcpy(codeletset_unload_req_error.codeletset_id.name, "non-existent-codeletset");
-    assert(jbpf_lcm_ipc_send_codeletset_unload_req(&address, &codeletset_unload_req_error) == JBPF_LCM_IPC_REQ_FAIL);
+    __assert__(jbpf_lcm_ipc_send_codeletset_unload_req(&address, &codeletset_unload_req_error) == JBPF_LCM_IPC_REQ_FAIL);
 
     // Tests are done. Let the agent know that it can terminate
     sem_post(lcm_ipc_agent_sem);

--- a/jbpf_tests/e2e_examples/jbpf_e2e_standalone_test.c
+++ b/jbpf_tests/e2e_examples/jbpf_e2e_standalone_test.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 
@@ -78,7 +79,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -107,7 +108,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -117,7 +118,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Next, we load the codeletset with codelets C2 and C3 in hooks "test1" and "test2"
     strcpy(codeletset_req_c2_c3.codeletset_id.name, "shared_map_input_output_codeletset");
@@ -135,7 +136,7 @@ main(int argc, char** argv)
     // The input channel of the codelet does not have a serializer
     codeletset_req_c2_c3.codelet_descriptor[0].in_io_channel[0].has_serde = false;
 
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c2_c3.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -159,7 +160,7 @@ main(int argc, char** argv)
     // The name of the linked map as it appears in C2
     strcpy(codeletset_req_c2_c3.codelet_descriptor[1].linked_maps[0].linked_map_name, "shared_map");
 
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c2_c3.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -170,7 +171,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c2_c3.codelet_descriptor[1].hook_name, "test2");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c2_c3, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c2_c3, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Send 5 control inputs
     for (int i = 0; i < NUM_ITERATIONS; i++) {
@@ -193,10 +194,10 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "simple_output_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     strcpy(codeletset_unload_req_c2_c3.codeletset_id.name, "shared_map_input_output_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c2_c3, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c2_c3, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/array/array_access_test.c
+++ b/jbpf_tests/functional/array/array_access_test.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -60,7 +61,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -71,7 +72,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test_single_result");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // iterate the increment operation
     for (int iter = 0; iter < MAX_ITERATION; ++iter) {
@@ -83,7 +84,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/codeletSets/codeletSet_LinkedMaps_cyclicCodelets.c
+++ b/jbpf_tests/functional/codeletSets/codeletSet_LinkedMaps_cyclicCodelets.c
@@ -20,6 +20,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_CODELETS (3)
 
@@ -101,7 +102,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -126,7 +127,7 @@ main(int argc, char** argv)
         cod_desc->priority = UINT_MAX - cod;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             cod_desc->codelet_path,
             JBPF_PATH_LEN,
@@ -170,7 +171,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Call the hooks 5 times and check that we got the expected data
     struct packet p = {1, 0};
@@ -185,7 +186,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/codeletSets/codeletSet_loadTwice.c
+++ b/jbpf_tests/functional/codeletSets/codeletSet_loadTwice.c
@@ -26,6 +26,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 #define NUM_CODELET_SETS (2)
@@ -97,7 +98,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -131,7 +132,7 @@ main(int argc, char** argv)
         cs_load_req->codelet_descriptor[0].out_io_channel[0].has_serde = false;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             cs_load_req->codelet_descriptor[0].codelet_path,
             JBPF_PATH_LEN,
@@ -145,7 +146,7 @@ main(int argc, char** argv)
             i);
         strcpy(cs_load_req->codelet_descriptor[0].hook_name, "test1");
         cs_load_req->codelet_descriptor[0].num_linked_maps = 0;
-        assert(jbpf_codeletset_load(cs_load_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+        __assert__(jbpf_codeletset_load(cs_load_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
     }
 
     // Call the hooks 5 times and check that we got the expected data
@@ -163,10 +164,10 @@ main(int argc, char** argv)
         codeletset_unload_req[i].codeletset_id = codeletset_load_req[i].codeletset_id;
         if (i == 0) {
             // the 1st codeletSet should be unloaded successfully
-            assert(jbpf_codeletset_unload(&codeletset_unload_req[i], NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+            __assert__(jbpf_codeletset_unload(&codeletset_unload_req[i], NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
         } else {
             // the 2nd codeletSet should fail to unload
-            assert(jbpf_codeletset_unload(&codeletset_unload_req[i], NULL) == JBPF_CODELET_UNLOAD_FAIL);
+            __assert__(jbpf_codeletset_unload(&codeletset_unload_req[i], NULL) == JBPF_CODELET_UNLOAD_FAIL);
         }
     }
 

--- a/jbpf_tests/functional/codeletSets/codeletSet_multiple_withSameHook.c
+++ b/jbpf_tests/functional/codeletSets/codeletSet_multiple_withSameHook.c
@@ -18,6 +18,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 #define NUM_CODELET_SETS (2)
@@ -91,7 +92,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -125,7 +126,7 @@ main(int argc, char** argv)
         cs_load_req->codelet_descriptor[0].out_io_channel[0].has_serde = false;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             cs_load_req->codelet_descriptor[0].codelet_path,
             JBPF_PATH_LEN,
@@ -137,7 +138,7 @@ main(int argc, char** argv)
         cs_load_req->codelet_descriptor[0].num_linked_maps = 0;
 
         // Load the codeletset
-        assert(jbpf_codeletset_load(cs_load_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+        __assert__(jbpf_codeletset_load(cs_load_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
     }
 
     // Call the hooks 5 times and check that we got the expected data
@@ -154,7 +155,7 @@ main(int argc, char** argv)
     // Unload the codeletsets
     for (int i = 0; i < sizeof(codeletset_load_req) / sizeof(codeletset_load_req[0]); i++) {
         codeletset_unload_req[i].codeletset_id = codeletset_load_req[i].codeletset_id;
-        assert(jbpf_codeletset_unload(&codeletset_unload_req[i], NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+        __assert__(jbpf_codeletset_unload(&codeletset_unload_req[i], NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
     }
 
     // Stop

--- a/jbpf_tests/functional/codeletSets/codeletSet_priority.c
+++ b/jbpf_tests/functional/codeletSets/codeletSet_priority.c
@@ -24,6 +24,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 #define TOTAL_HOOK_CALLS (NUM_ITERATIONS * JBPF_MAX_CODELETS_IN_CODELETSET)
@@ -123,7 +124,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -162,7 +163,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].out_io_channel[0].has_serde = false;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -192,7 +193,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Call the hooks 5 times and check that we got the expected data
     struct packet p = {0, 0};
@@ -206,7 +207,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/codeletSets/codeletSet_unload_Unknown.c
+++ b/jbpf_tests/functional/codeletSets/codeletSet_unload_Unknown.c
@@ -17,6 +17,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_ids[] = {
     {.id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x00}}};
@@ -33,7 +34,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -62,7 +63,7 @@ main(int argc, char** argv)
     cs_load_req->codelet_descriptor[0].out_io_channel[0].has_serde = false;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         cs_load_req->codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -74,15 +75,15 @@ main(int argc, char** argv)
     cs_load_req->codelet_descriptor[0].num_linked_maps = 0;
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(cs_load_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(cs_load_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // unload unknown codeletSet
     snprintf(codeletset_unload_req.codeletset_id.name, JBPF_CODELETSET_NAME_LEN, "unknown_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req, NULL) == JBPF_CODELET_UNLOAD_FAIL);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req, NULL) == JBPF_CODELET_UNLOAD_FAIL);
 
     // unload the correct codeletSet
     codeletset_unload_req.codeletset_id = codeletset_load_req.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/codelets/codelet_InChannel_flood.c
+++ b/jbpf_tests/functional/codelets/codelet_InChannel_flood.c
@@ -25,6 +25,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_IN_CHANNELS (2)
 #define IN_CHANNEL_SIZE (100)
@@ -145,7 +146,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     assert(OUTPUT_BIN_SIZE >= ACTUAL_IN_CHANNEL_SIZE);
 
@@ -199,7 +200,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -210,7 +211,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test3");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Flood the input channels with control inputs.
     // Call the hooks 5 times and check that we got the expected data
@@ -242,7 +243,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/codelets/codelet_OutChannel_flood.c
+++ b/jbpf_tests/functional/codelets/codelet_OutChannel_flood.c
@@ -18,6 +18,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS (5)
 #define TOTAL_HOOK_CALLS (NUM_ITERATIONS)
@@ -70,7 +71,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -99,7 +100,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -110,7 +111,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Call the hooks 5 times and check that we got the expected data
 
@@ -128,7 +129,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/codelets/codelet_hook_max.c
+++ b/jbpf_tests/functional/codelets/codelet_hook_max.c
@@ -19,6 +19,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS (5)
 #define TOTAL_HOOK_CALLS (NUM_ITERATIONS)
@@ -74,7 +75,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -103,7 +104,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -119,7 +120,7 @@ main(int argc, char** argv)
         "89abcdef0123456789abcdef0123456789a");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Call the hooks 5 times and check that we got the expected data
     struct packet p = {0, 0};
@@ -135,7 +136,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/codelets/codelet_hook_sameSuffix.c
+++ b/jbpf_tests/functional/codelets/codelet_hook_sameSuffix.c
@@ -23,6 +23,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS (5)
 #define TOTAL_HOOK_CALLS (NUM_ITERATIONS)
@@ -77,7 +78,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -106,7 +107,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -117,7 +118,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Call the hooks 5 times and check that we got the expected data
     struct packet p = {0, 0};
@@ -134,7 +135,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/codelets/codelet_multiThread_perThreadArray.c
+++ b/jbpf_tests/functional/codelets/codelet_multiThread_perThreadArray.c
@@ -22,6 +22,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS (5)
 #define NUM_THREADS (5)
@@ -110,7 +111,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -143,7 +144,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -155,7 +156,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     for (int i = 0; i < sizeof(test_threads) / sizeof(test_threads[0]); i++) {
         sem_post(&sync_sem);
@@ -171,7 +172,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/ctrl_hooks/ctrlHook_checkReturns.c
+++ b/jbpf_tests/functional/ctrl_hooks/ctrlHook_checkReturns.c
@@ -25,6 +25,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t out_stream_id = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -98,7 +99,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -141,7 +142,7 @@ main(int argc, char** argv)
     cod_desc->num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         cod_desc->codelet_path,
         JBPF_PATH_LEN,
@@ -152,7 +153,7 @@ main(int argc, char** argv)
     strcpy(cod_desc->hook_name, "ctrl_test0");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Send NUM_IN_MESSAGES messages to the input channel
     for (int i = 0; i < NUM_IN_MESSAGES; i++) {
@@ -161,7 +162,7 @@ main(int argc, char** argv)
 
         JBPF_UNUSED(control_input);
 
-        assert(jbpf_send_input_msg(&in_stream_id, &control_input, sizeof(control_input)) == 0);
+        __assert__(jbpf_send_input_msg(&in_stream_id, &control_input, sizeof(control_input)) == 0);
     }
 
     // Call the hooks NUM_ITERATIONS times and check that we got the expected data
@@ -193,7 +194,7 @@ main(int argc, char** argv)
     jbpf_codeletset_unload_req_s codeletset_unload_req;
     jbpf_codeletset_unload_req_s* codset_unload_req = &codeletset_unload_req;
     codset_unload_req->codeletset_id = codset_req->codeletset_id;
-    assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/ctrl_hooks/ctrlHook_multipleCodeletSets.c
+++ b/jbpf_tests/functional/ctrl_hooks/ctrlHook_multipleCodeletSets.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_CODELET_SETS (2)
 #define NUM_CODELETS_IN_CODELETSET (1)
@@ -38,7 +39,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -87,7 +88,7 @@ main(int argc, char** argv)
             cod_desc->num_linked_maps = 0;
 
             // The path of the codelet
-            assert(jbpf_path != NULL);
+            __assert__(jbpf_path != NULL);
             snprintf(
                 cod_desc->codelet_path,
                 JBPF_PATH_LEN,
@@ -100,9 +101,9 @@ main(int argc, char** argv)
         }
 
         if (codset == 0) {
-            assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+            __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
         } else {
-            assert(jbpf_codeletset_load(codset_req, &err_msg) == JBPF_CODELET_LOAD_FAIL);
+            __assert__(jbpf_codeletset_load(codset_req, &err_msg) == JBPF_CODELET_LOAD_FAIL);
             printf("err_msg = %s", err_msg.err_msg);
         }
     }
@@ -117,9 +118,9 @@ main(int argc, char** argv)
             "control-input-withFailures_codeletset-%d",
             codset);
         if (codset == 0) {
-            assert(jbpf_codeletset_unload(codset_unload_req, &err_msg) == JBPF_CODELET_UNLOAD_SUCCESS);
+            __assert__(jbpf_codeletset_unload(codset_unload_req, &err_msg) == JBPF_CODELET_UNLOAD_SUCCESS);
         } else {
-            assert(jbpf_codeletset_unload(codset_unload_req, &err_msg) == JBPF_CODELET_UNLOAD_FAIL);
+            __assert__(jbpf_codeletset_unload(codset_unload_req, &err_msg) == JBPF_CODELET_UNLOAD_FAIL);
             assert(strlen(err_msg.err_msg) > 0);
             printf("err_msg = %s", err_msg.err_msg);
         }

--- a/jbpf_tests/functional/ctrl_hooks/ctrlHook_multipleCodelets.c
+++ b/jbpf_tests/functional/ctrl_hooks/ctrlHook_multipleCodelets.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_CODELET_SETS (1)
 #define NUM_CODELETS_IN_CODELETSET (2)
@@ -36,7 +37,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -85,7 +86,7 @@ main(int argc, char** argv)
             cod_desc->num_linked_maps = 0;
 
             // The path of the codelet
-            assert(jbpf_path != NULL);
+            __assert__(jbpf_path != NULL);
             snprintf(
                 cod_desc->codelet_path,
                 JBPF_PATH_LEN,
@@ -98,7 +99,7 @@ main(int argc, char** argv)
         }
 
         // Load the codeletset
-        assert(jbpf_codeletset_load(codset_req, &err_msg) == JBPF_CODELET_LOAD_FAIL);
+        __assert__(jbpf_codeletset_load(codset_req, &err_msg) == JBPF_CODELET_LOAD_FAIL);
         assert(strlen(err_msg.err_msg) > 0);
         printf("err_msg = %s", err_msg.err_msg);
     }
@@ -112,7 +113,7 @@ main(int argc, char** argv)
             JBPF_CODELETSET_NAME_LEN,
             "control-input-withFailures_codeletset-%d",
             codset);
-        assert(jbpf_codeletset_unload(codset_unload_req, &err_msg) == JBPF_CODELET_UNLOAD_FAIL);
+        __assert__(jbpf_codeletset_unload(codset_unload_req, &err_msg) == JBPF_CODELET_UNLOAD_FAIL);
         assert(strlen(err_msg.err_msg) > 0);
         printf("err_msg = %s", err_msg.err_msg);
     }

--- a/jbpf_tests/functional/helper_functions/jbpf_fixpoint_codelet_test.c
+++ b/jbpf_tests/functional/helper_functions/jbpf_fixpoint_codelet_test.c
@@ -25,6 +25,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 #include <math.h>
 
 jbpf_io_stream_id_t stream_id_c1 = {
@@ -47,7 +48,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -80,7 +81,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test_single_result");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // iterate the increment operation
     for (int iter = 0; iter < MAX_ITERATION; ++iter) {
@@ -130,7 +131,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/helper_functions/jbpf_hash_codelet_test.c
+++ b/jbpf_tests/functional/helper_functions/jbpf_hash_codelet_test.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -36,7 +37,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -58,7 +59,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     snprintf(codeletset_req_c1.codelet_descriptor[0].hook_name, JBPF_HOOK_NAME_LEN, "test_single_result");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // iterate the increment operation
     for (int iter = 0; iter < MAX_ITERATION; ++iter) {
@@ -81,7 +82,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/helper_functions/replacing_time_event_helper_function_test.c
+++ b/jbpf_tests/functional/helper_functions/replacing_time_event_helper_function_test.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 100
 
@@ -70,7 +71,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // replacing the helper function jbpf_time_get_ns
     jbpf_helper_func_def_t helper_func1;
@@ -78,7 +79,7 @@ main(int argc, char** argv)
     helper_func1.reloc_id = JBPF_TIME_GET_NS;
     helper_func1.function_cb = (jbpf_helper_func_t)jbpf_perf_time_get_ns_replacement;
 
-    assert(jbpf_register_helper_function(helper_func1) == 1);
+    __assert__(jbpf_register_helper_function(helper_func1) == 1);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -105,7 +106,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -115,7 +116,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Call the hooks NUM_ITERATIONS times and check that we got the expected data
     struct packet p = {0, 0};
@@ -129,7 +130,7 @@ main(int argc, char** argv)
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "time_events_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/io/jbpf_io_local_test.c
+++ b/jbpf_tests/functional/io/jbpf_io_local_test.c
@@ -27,6 +27,7 @@
 #include "jbpf_io_queue.h"
 #include "jbpf_io_channel.h"
 #include "jbpf_io_utils.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_INSERTIONS 4
 
@@ -204,16 +205,16 @@ main(int argc, char* argv[])
         0);
 
     // Channel with stream id 1 exists
-    assert(jbpf_io_find_channel(io_ctx, stream_id2, true));
+    __assert__(jbpf_io_find_channel(io_ctx, stream_id2, true) != NULL);
 
     // Channel with stream id 1 is output channel
-    assert(!jbpf_io_find_channel(io_ctx, stream_id2, false));
+    __assert__(jbpf_io_find_channel(io_ctx, stream_id2, false) == NULL);
 
     // Channel with stream id 2 exists
-    assert(jbpf_io_find_channel(io_ctx, stream_id2, true));
+    __assert__(jbpf_io_find_channel(io_ctx, stream_id2, true) != NULL);
 
     // Channel with stream id 3 does not exist
-    assert(jbpf_io_find_channel(io_ctx, stream_id2, true));
+    __assert__(jbpf_io_find_channel(io_ctx, stream_id2, true) != NULL);
 
     for (int i = 0; i < NUM_INSERTIONS - 1; i++) {
         test_data1 = jbpf_io_channel_reserve_buf(io_channel);
@@ -245,9 +246,9 @@ main(int argc, char* argv[])
         JBPF_IO_UNUSED(buf);
 
         // Check that serialization will fail if we don't give big enough buffer
-        assert(jbpf_io_channel_pack_msg(io_ctx, test_data1, serialized, 4) == -1);
+        __assert__(jbpf_io_channel_pack_msg(io_ctx, test_data1, serialized, 4) == -1);
 #endif
-        assert(jbpf_io_channel_submit_buf(io_channel) == 0);
+        __assert__(jbpf_io_channel_submit_buf(io_channel) == 0);
     }
 
     test_data_tmp.counter_a = NUM_INSERTIONS - 1;
@@ -255,7 +256,7 @@ main(int argc, char* argv[])
 
     jbpf_io_channel_send_data(io_channel, &test_data_tmp, sizeof(test_data_tmp));
 
-    assert(jbpf_io_channel_submit_buf(io_channel) == -2);
+    __assert__(jbpf_io_channel_submit_buf(io_channel) == -2);
 
     for (int i = 0; i < NUM_INSERTIONS; i++) {
         test_data2 = jbpf_io_channel_reserve_buf(io_channel2);
@@ -272,7 +273,7 @@ main(int argc, char* argv[])
             strncmp(serialized + JBPF_IO_STREAM_ID_LEN, serialized_output, serialized_size - JBPF_IO_STREAM_ID_LEN) ==
             0);
 #endif
-        assert(jbpf_io_channel_submit_buf(io_channel2) == 0);
+        __assert__(jbpf_io_channel_submit_buf(io_channel2) == 0);
     }
 
     // Write some data to each channel and make sure you get the same data out

--- a/jbpf_tests/functional/jbpf_unit_test.c
+++ b/jbpf_tests/functional/jbpf_unit_test.c
@@ -366,19 +366,19 @@ test_hashmap_map(void** state)
     /* Add the same element again */
     res = jbpf_bpf_hashmap_update_elem(map, &key1, &val1, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 1);
+    __assert__(jbpf_bpf_hashmap_size(map) == 1);
 
     res = jbpf_bpf_hashmap_update_elem(map, &key2, &val2, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 2);
+    __assert__(jbpf_bpf_hashmap_size(map) == 2);
 
     res = jbpf_bpf_hashmap_update_elem(map, &key3, &val3, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 3);
+    __assert__(jbpf_bpf_hashmap_size(map) == 3);
 
     res = jbpf_bpf_hashmap_update_elem(map, key4, &val4, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 4);
+    __assert__(jbpf_bpf_hashmap_size(map) == 4);
 
     /* The map should be full by now */
     res = jbpf_bpf_hashmap_update_elem(map, &key5, &val5, 0);
@@ -409,7 +409,7 @@ test_hashmap_map(void** state)
     /* Delete an existing key */
     res = jbpf_bpf_hashmap_delete_elem(map, &key1);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 3);
+    __assert__(jbpf_bpf_hashmap_size(map) == 3);
 
     /* Lookup and delete a non-existent pair */
     val = jbpf_bpf_hashmap_lookup_elem(map, &key5);
@@ -439,19 +439,19 @@ test_hashmap_map_dump(void** state)
     /* Add the same element again */
     res = jbpf_bpf_hashmap_update_elem(map, &key1, &val1, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 1);
+    __assert__(jbpf_bpf_hashmap_size(map) == 1);
 
     res = jbpf_bpf_hashmap_update_elem(map, &key2, &val2, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 2);
+    __assert__(jbpf_bpf_hashmap_size(map) == 2);
 
     res = jbpf_bpf_hashmap_update_elem(map, &key3, &val3, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 3);
+    __assert__(jbpf_bpf_hashmap_size(map) == 3);
 
     res = jbpf_bpf_hashmap_update_elem(map, &key4, &val4, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 4);
+    __assert__(jbpf_bpf_hashmap_size(map) == 4);
 
     /* There is enough space, so all elements should be dumped */
     res = jbpf_bpf_hashmap_dump(map, reg1, sizeof(reg1), 0);
@@ -520,19 +520,19 @@ test_hashmap_map_clear(void** state)
 
     res = jbpf_bpf_hashmap_update_elem(map, &key2, &val2, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 2);
+    __assert__(jbpf_bpf_hashmap_size(map) == 2);
 
     res = jbpf_bpf_hashmap_update_elem(map, &key3, &val3, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 3);
+    __assert__(jbpf_bpf_hashmap_size(map) == 3);
 
     res = jbpf_bpf_hashmap_update_elem(map, &key4, &val4, 0);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 4);
+    __assert__(jbpf_bpf_hashmap_size(map) == 4);
 
     res = jbpf_bpf_hashmap_clear(map);
     assert(res == 0);
-    assert(jbpf_bpf_hashmap_size(map) == 0);
+    __assert__(jbpf_bpf_hashmap_size(map) == 0);
 }
 
 int

--- a/jbpf_tests/functional/load_unload/graceful_stop.c
+++ b/jbpf_tests/functional/load_unload/graceful_stop.c
@@ -19,6 +19,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 1000
 #define TOTAL_HOOK_CALLS (NUM_ITERATIONS * JBPF_MAX_CODELETS_IN_CODELETSET)
@@ -125,7 +126,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -175,7 +176,7 @@ main(int argc, char** argv)
             cod_desc->num_linked_maps = 0;
 
             // The path of the codelet
-            assert(jbpf_path != NULL);
+            __assert__(jbpf_path != NULL);
             snprintf(
                 cod_desc->codelet_path,
                 JBPF_PATH_LEN,
@@ -196,7 +197,7 @@ main(int argc, char** argv)
         // printf("\n----------------------------\n%s\n", ddd);
 
         // printf("Loading codeletset %s\n", codset_req->codeletset_id.name);
-        assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+        __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
     }
 
     usleep(1000000);

--- a/jbpf_tests/functional/load_unload/load_unload_repeated.c
+++ b/jbpf_tests/functional/load_unload/load_unload_repeated.c
@@ -20,6 +20,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_CODELET_SETS (JBPF_MAX_LOADED_CODELETSETS)
 #define NUM_CODELETS_IN_CODELETSET (1)
@@ -69,7 +70,7 @@ load_codelet_set(jbpf_codeletset_load_req_s* codset_req, int codset)
         cod_desc->num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             cod_desc->codelet_path,
             JBPF_PATH_LEN,
@@ -81,7 +82,7 @@ load_codelet_set(jbpf_codeletset_load_req_s* codset_req, int codset)
 
     // Load the codeletsets
     printf("Loading codeletset %s\n", codset_req->codeletset_id.name);
-    assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 }
 
 int
@@ -96,7 +97,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -112,10 +113,10 @@ main(int argc, char** argv)
     int codset_id = 0;
 
     struct jbpf_ctx_t* jbpf_ctx = jbpf_get_ctx();
-    assert(jbpf_ctx != NULL);
+    __assert__(jbpf_ctx != NULL);
     assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == 64);
-    assert(jbpf_ctx->total_num_codelets == 64);
-    assert(jbpf_ctx->nmap_reg == 128);
+    __assert__(jbpf_ctx->total_num_codelets == 64);
+    __assert__(jbpf_ctx->nmap_reg == 128);
 
     for (int i = 0; i < 1000; i++) {
 
@@ -136,12 +137,12 @@ main(int argc, char** argv)
             snprintf(
                 codset_unload_req->codeletset_id.name, JBPF_CODELETSET_NAME_LEN, "simple_output_codeletset%d", cs_id);
             printf("Unloading codeletset %s\n", codset_unload_req->codeletset_id.name);
-            assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+            __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
             total_unloaded++;
 
             assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == old_codeletset_registry_count - 1);
-            assert(jbpf_ctx->total_num_codelets == jbpf_ctx_old.total_num_codelets - 1);
-            assert(jbpf_ctx->nmap_reg == jbpf_ctx_old.nmap_reg - 2);
+            __assert__(jbpf_ctx->total_num_codelets == jbpf_ctx_old.total_num_codelets - 1);
+            __assert__(jbpf_ctx->nmap_reg == jbpf_ctx_old.nmap_reg - 2);
         }
 
         // load 8 codeletSets
@@ -158,8 +159,8 @@ main(int argc, char** argv)
             load_codelet_set(&codeletset_req, cs_id);
             total_loaded++;
             assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == old_codeletset_registry_count + 1);
-            assert(jbpf_ctx->total_num_codelets == jbpf_ctx_old.total_num_codelets + 1);
-            assert(jbpf_ctx->nmap_reg == jbpf_ctx_old.nmap_reg + 2);
+            __assert__(jbpf_ctx->total_num_codelets == jbpf_ctx_old.total_num_codelets + 1);
+            __assert__(jbpf_ctx->nmap_reg == jbpf_ctx_old.nmap_reg + 2);
         }
 
         codset_id += 8;
@@ -183,26 +184,26 @@ main(int argc, char** argv)
         int old_codeletset_registry_count = ck_ht_count(&jbpf_ctx->codeletset_registry);
         JBPF_UNUSED(jbpf_ctx_old);
         JBPF_UNUSED(old_codeletset_registry_count);
-        assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+        __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
         total_unloaded++;
         assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == old_codeletset_registry_count - 1);
-        assert(jbpf_ctx->total_num_codelets == jbpf_ctx_old.total_num_codelets - 1);
-        assert(jbpf_ctx->nmap_reg == jbpf_ctx_old.nmap_reg - 2);
+        __assert__(jbpf_ctx->total_num_codelets == jbpf_ctx_old.total_num_codelets - 1);
+        __assert__(jbpf_ctx->nmap_reg == jbpf_ctx_old.nmap_reg - 2);
     }
 
     printf("Total codeletsets loaded %d unloaded %d\n", total_loaded, total_unloaded);
 
     // check the stats of the jbpf_ctx
     jbpf_ctx = jbpf_get_ctx();
-    assert(jbpf_ctx != NULL);
+    __assert__(jbpf_ctx != NULL);
     // printf(
     //     "jbpf_ctx after unloading all codelets : num_codeletSets = %ld nmap_reg %d total_num_codelets %d \n",
     //     ck_ht_count(&jbpf_ctx->codeletset_registry),
     //     jbpf_ctx->nmap_reg,
     //     jbpf_ctx->total_num_codelets);
     assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == 0);
-    assert(jbpf_ctx->total_num_codelets == 0);
-    assert(jbpf_ctx->nmap_reg == 0);
+    __assert__(jbpf_ctx->total_num_codelets == 0);
+    __assert__(jbpf_ctx->nmap_reg == 0);
 
     // Cleanup and stop
     jbpf_stop();

--- a/jbpf_tests/functional/load_unload/max_loaded_codeletSets.c
+++ b/jbpf_tests/functional/load_unload/max_loaded_codeletSets.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_CODELET_SETS (JBPF_MAX_LOADED_CODELETSETS)
 #define NUM_CODELETS_IN_CODELETSET (1)
@@ -33,7 +34,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -80,7 +81,7 @@ main(int argc, char** argv)
             cod_desc->num_linked_maps = 0;
 
             // The path of the codelet
-            assert(jbpf_path != NULL);
+            __assert__(jbpf_path != NULL);
             snprintf(
                 cod_desc->codelet_path,
                 JBPF_PATH_LEN,
@@ -92,7 +93,7 @@ main(int argc, char** argv)
 
         // Load the codeletsets
         // printf("Loading codeletset %s\n", codset_req->codeletset_id.name);
-        assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+        __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
     }
 
     usleep(1000000);
@@ -103,7 +104,7 @@ main(int argc, char** argv)
         jbpf_codeletset_unload_req_s* codset_unload_req = &codeletset_unload_req;
         snprintf(codset_unload_req->codeletset_id.name, JBPF_CODELETSET_NAME_LEN, "simple_output_codeletset%d", codset);
         // printf("Unloading codeletset %s\n", codset_unload_req->codeletset_id.name);
-        assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+        __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
     }
 
     // Cleanup and stop

--- a/jbpf_tests/functional/load_unload/max_loaded_codeletSets_exceeded.c
+++ b/jbpf_tests/functional/load_unload/max_loaded_codeletSets_exceeded.c
@@ -20,6 +20,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_CODELET_SETS (JBPF_MAX_LOADED_CODELETSETS + 1) // PLus 1 to exceed max codelets limit
 #define NUM_CODELETS_IN_CODELETSET (1)
@@ -39,7 +40,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -86,7 +87,7 @@ main(int argc, char** argv)
             cod_desc->num_linked_maps = 0;
 
             // The path of the codelet
-            assert(jbpf_path != NULL);
+            __assert__(jbpf_path != NULL);
             snprintf(
                 cod_desc->codelet_path,
                 JBPF_PATH_LEN,
@@ -99,15 +100,15 @@ main(int argc, char** argv)
         // Load the codeletsets
         // printf("Loading codletset %s\n", codset_req->codeletset_id.name);
         if (codset == NUM_CODELET_SETS - 1) {
-            assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_CREATION_FAIL);
+            __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_CREATION_FAIL);
         } else {
-            assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+            __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
         }
 
         // check the stats of the jbpf_ctx
         struct jbpf_ctx_t* jbpf_ctx = jbpf_get_ctx();
         JBPF_UNUSED(jbpf_ctx);
-        assert(jbpf_ctx != NULL);
+        __assert__(jbpf_ctx != NULL);
         // printf(
         //     "jbpf_ctx after loading %s : num_codeletSets = %ld nmap_reg %d total_num_codelets %d \n",
         //     codset_req->codeletset_id.name,
@@ -117,7 +118,7 @@ main(int argc, char** argv)
         int expected_num_loaded_codeletSets = (codset == NUM_CODELET_SETS - 1) ? codset : codset + 1;
         JBPF_UNUSED(expected_num_loaded_codeletSets);
         assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == expected_num_loaded_codeletSets);
-        assert(jbpf_ctx->total_num_codelets == expected_num_loaded_codeletSets * NUM_CODELETS_IN_CODELETSET);
+        __assert__(jbpf_ctx->total_num_codelets == expected_num_loaded_codeletSets * NUM_CODELETS_IN_CODELETSET);
         assert(
             jbpf_ctx->nmap_reg == expected_num_loaded_codeletSets * NUM_CODELETS_IN_CODELETSET * NUM_MAPS_PER_CODELET);
     }
@@ -131,24 +132,24 @@ main(int argc, char** argv)
         snprintf(codset_unload_req->codeletset_id.name, JBPF_CODELETSET_NAME_LEN, "simple_output_codeletset%d", codset);
         // printf("Unloading codeletset %s\n", codset_unload_req->codeletset_id.name);
         if (codset == NUM_CODELET_SETS - 1) {
-            assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_FAIL);
+            __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_FAIL);
         } else {
-            assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+            __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
         }
     }
 
     // check the stats of the jbpf_ctx
     struct jbpf_ctx_t* jbpf_ctx = jbpf_get_ctx();
     JBPF_UNUSED(jbpf_ctx);
-    assert(jbpf_ctx != NULL);
+    __assert__(jbpf_ctx != NULL);
     // printf(
     //     "jbpf_ctx after unloading all codelets : num_codeletSets = %ld nmap_reg %d total_num_codelets %d \n",
     //     ck_ht_count(&jbpf_ctx->codeletset_registry),
     //     jbpf_ctx->nmap_reg,
     //     jbpf_ctx->total_num_codelets);
     assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == 0);
-    assert(jbpf_ctx->total_num_codelets == 0);
-    assert(jbpf_ctx->nmap_reg == 0);
+    __assert__(jbpf_ctx->total_num_codelets == 0);
+    __assert__(jbpf_ctx->nmap_reg == 0);
 
     // Cleanup and stop
     jbpf_stop();

--- a/jbpf_tests/functional/load_unload/max_loaded_codelets.c
+++ b/jbpf_tests/functional/load_unload/max_loaded_codelets.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_CODELET_SETS (JBPF_MAX_LOADED_CODELETSETS / 2)
 #define NUM_CODELETS_IN_CODELETSET (2)
@@ -36,7 +37,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -83,7 +84,7 @@ main(int argc, char** argv)
             cod_desc->num_linked_maps = 0;
 
             // The path of the codelet
-            assert(jbpf_path != NULL);
+            __assert__(jbpf_path != NULL);
             snprintf(
                 cod_desc->codelet_path,
                 JBPF_PATH_LEN,
@@ -95,7 +96,7 @@ main(int argc, char** argv)
 
         // Load the codeletsets
         // printf("Loading codeletset %s\n", codset_req->codeletset_id.name);
-        assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+        __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
     }
 
     usleep(1000000);
@@ -106,7 +107,7 @@ main(int argc, char** argv)
         jbpf_codeletset_unload_req_s* codset_unload_req = &codeletset_unload_req;
         snprintf(codset_unload_req->codeletset_id.name, JBPF_CODELETSET_NAME_LEN, "simple_output_codeletset%d", codset);
         // printf("Unloading codeletset %s\n", codset_unload_req->codeletset_id.name);
-        assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+        __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
     }
 
     // Cleanup and stop

--- a/jbpf_tests/functional/load_unload/max_loaded_codelets_exceeded.c
+++ b/jbpf_tests/functional/load_unload/max_loaded_codelets_exceeded.c
@@ -22,6 +22,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_CODELET_SETS ((JBPF_MAX_LOADED_CODELETSETS / 5) + 1) // PLus 1 to exceed max codelets limit
 #define NUM_CODELETS_IN_CODELETSET (5)
@@ -43,7 +44,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -90,7 +91,7 @@ main(int argc, char** argv)
             cod_desc->num_linked_maps = 0;
 
             // The path of the codelet
-            assert(jbpf_path != NULL);
+            __assert__(jbpf_path != NULL);
             snprintf(
                 cod_desc->codelet_path,
                 JBPF_PATH_LEN,
@@ -103,15 +104,15 @@ main(int argc, char** argv)
         // Load the codeletsets
         // printf("Loading codeletset %s\n", codset_req->codeletset_id.name);
         if (codset == NUM_CODELET_SETS - 1) {
-            assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_CREATION_FAIL);
+            __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_CREATION_FAIL);
         } else {
-            assert(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+            __assert__(jbpf_codeletset_load(codset_req, NULL) == JBPF_CODELET_LOAD_SUCCESS);
         }
 
         // check the stats of the jbpf_ctx
         struct jbpf_ctx_t* jbpf_ctx = jbpf_get_ctx();
         JBPF_UNUSED(jbpf_ctx);
-        assert(jbpf_ctx != NULL);
+        __assert__(jbpf_ctx != NULL);
         // printf(
         //     "jbpf_ctx after loading %s : num_codeletSets = %ld nmap_reg %d total_num_codelets %d \n",
         //     codset_req->codeletset_id.name,
@@ -121,7 +122,7 @@ main(int argc, char** argv)
         int expected_num_loaded_codeletSets = (codset == NUM_CODELET_SETS - 1) ? codset : codset + 1;
         JBPF_UNUSED(expected_num_loaded_codeletSets);
         assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == expected_num_loaded_codeletSets);
-        assert(jbpf_ctx->total_num_codelets == expected_num_loaded_codeletSets * NUM_CODELETS_IN_CODELETSET);
+        __assert__(jbpf_ctx->total_num_codelets == expected_num_loaded_codeletSets * NUM_CODELETS_IN_CODELETSET);
         assert(
             jbpf_ctx->nmap_reg == expected_num_loaded_codeletSets * NUM_CODELETS_IN_CODELETSET * NUM_MAPS_PER_CODELET);
     }
@@ -135,24 +136,24 @@ main(int argc, char** argv)
         snprintf(codset_unload_req->codeletset_id.name, JBPF_CODELETSET_NAME_LEN, "simple_output_codeletset%d", codset);
         // printf("Unloading codeletset %s\n", codset_unload_req->codeletset_id.name);
         if (codset == NUM_CODELET_SETS - 1) {
-            assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_FAIL);
+            __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_FAIL);
         } else {
-            assert(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+            __assert__(jbpf_codeletset_unload(codset_unload_req, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
         }
     }
 
     // check the stats of the jbpf_ctx
     struct jbpf_ctx_t* jbpf_ctx = jbpf_get_ctx();
     JBPF_UNUSED(jbpf_ctx);
-    assert(jbpf_ctx != NULL);
+    __assert__(jbpf_ctx != NULL);
     // printf(
     //     "jbpf_ctx after unloading all codelets : num_codeletSets = %ld nmap_reg %d total_num_codelets %d \n",
     //     ck_ht_count(&jbpf_ctx->codeletset_registry),
     //     jbpf_ctx->nmap_reg,
     //     jbpf_ctx->total_num_codelets);
     assert(ck_ht_count(&jbpf_ctx->codeletset_registry) == 0);
-    assert(jbpf_ctx->total_num_codelets == 0);
-    assert(jbpf_ctx->nmap_reg == 0);
+    __assert__(jbpf_ctx->total_num_codelets == 0);
+    __assert__(jbpf_ctx->nmap_reg == 0);
 
     // Cleanup and stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codeletSet_CodeletDescriptors_empty.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_CodeletDescriptors_empty.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -44,7 +45,7 @@ main(int argc, char** argv)
     codeletset_req_c1.num_codelet_descriptors = 0;
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codeletSet_CodeletDescriptors_max.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_CodeletDescriptors_max.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -30,7 +31,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -60,7 +61,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -72,11 +73,11 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "simple_output_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codeletSet_CodeletDescriptors_maxExceeded.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_CodeletDescriptors_maxExceeded.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -64,7 +65,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -76,7 +77,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codeletSet_CodeletDescriptors_null.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_CodeletDescriptors_null.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -64,7 +65,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -76,7 +77,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codeletSet_Id_maxLen.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_Id_maxLen.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -66,7 +67,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -78,11 +79,11 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletset
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
     // Stop
     jbpf_stop();
 

--- a/jbpf_tests/functional/request_validation/codeletSet_Id_notSet.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_Id_notSet.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -33,7 +34,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -63,7 +64,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -75,7 +76,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codeletSet_Id_tooLong.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_Id_tooLong.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -68,7 +69,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -80,7 +81,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codeletSet_duplicateCodeletNames.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_duplicateCodeletNames.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -30,7 +31,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -60,7 +61,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -73,7 +74,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_PARAM_INVALID);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codeletSet_duplicateStreamIds.c
+++ b/jbpf_tests/functional/request_validation/codeletSet_duplicateStreamIds.c
@@ -17,6 +17,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -65,7 +66,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[i].num_linked_maps = 0;
 
         // The path of the codelet
-        assert(jbpf_path != NULL);
+        __assert__(jbpf_path != NULL);
         snprintf(
             codeletset_req_c1.codelet_descriptor[i].codelet_path,
             JBPF_PATH_LEN,
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_Name_maxLen.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_Name_maxLen.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -82,11 +83,11 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "simple_input_shared_maxLen_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_Name_notSet.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_Name_notSet.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -75,7 +76,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_input_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_Name_tooLong.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_Name_tooLong.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_input_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_Serde_maxLen.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_Serde_maxLen.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -37,7 +38,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -86,7 +87,7 @@ main(int argc, char** argv)
     // Load the codeletset
     // Note that the laod will fail because the Serde is not known, but it is checking that the message shows that the
     // file does not exist, as opposed to being too long
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
     assert(
         strncmp(err_msg.err_msg, "in_io_channel.serde does not exist", strlen("in_io_channel.serde does not exist")) ==

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_Serde_notSet.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_Serde_notSet.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_input_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_Serde_tooLong.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_Serde_tooLong.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -79,7 +80,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_input_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_Serde_unknown.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_Serde_unknown.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_input_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_map_unknown.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_map_unknown.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -79,7 +80,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_mismatch.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_mismatch.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -67,7 +68,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Cleanup and stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannel_null.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannel_null.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -66,7 +67,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_InChannels_max.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannels_max.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -31,7 +32,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -63,7 +64,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -73,11 +74,11 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "max_input_shared_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codelet_InChannels_maxExceeded.c
+++ b/jbpf_tests/functional/request_validation/codelet_InChannels_maxExceeded.c
@@ -17,6 +17,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -67,7 +68,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_LinkedCodeletName_unknown.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_LinkedCodeletName_unknown.c
@@ -21,6 +21,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -42,7 +43,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -99,7 +100,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].linked_maps[0].linked_map_name, "shared_map");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -110,7 +111,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Cleanup and stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_LinkedMapName_InputChannel.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_LinkedMapName_InputChannel.c
@@ -21,6 +21,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -42,7 +43,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -101,7 +102,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].linked_maps[0].linked_map_name, "input_map");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -112,7 +113,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_LinkedMapName_OutputChannel.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_LinkedMapName_OutputChannel.c
@@ -21,6 +21,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -42,7 +43,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -73,7 +74,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].linked_maps[0].linked_map_name, "output_map");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -101,7 +102,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[1].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -112,7 +113,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_LinkedMapName_unknown.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_LinkedMapName_unknown.c
@@ -21,6 +21,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -42,7 +43,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -101,7 +102,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].linked_maps[0].linked_map_name, "unknown_map");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -112,7 +113,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Cleanup and stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_MapName_InputChannel.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_MapName_InputChannel.c
@@ -22,6 +22,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -43,7 +44,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -74,7 +75,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].linked_maps[0].linked_map_name, "shared_map_output");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -102,7 +103,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[1].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -113,7 +114,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_MapName_OutputChannel.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_MapName_OutputChannel.c
@@ -22,6 +22,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -43,7 +44,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -70,7 +71,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -102,7 +103,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].linked_maps[0].linked_map_name, "shared_map");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -113,7 +114,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_MapName_unknown.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_MapName_unknown.c
@@ -21,6 +21,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -42,7 +43,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -101,7 +102,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].linked_maps[0].linked_map_name, "shared_map");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -112,7 +113,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_LOAD_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_LOAD_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_mismatchedSize.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_mismatchedSize.c
@@ -22,6 +22,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -43,7 +44,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -70,7 +71,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -102,7 +103,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].linked_maps[0].linked_map_name, "shared_map");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -113,7 +114,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_null.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_null.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -68,7 +69,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -117,7 +118,7 @@ main(int argc, char** argv)
     }
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -127,7 +128,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].codelet_name, "max_output_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMap_sameCodelet.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMap_sameCodelet.c
@@ -22,6 +22,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -43,7 +44,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -70,7 +71,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -99,7 +100,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].linked_maps[0].linked_map_name, "shared_map_output1");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -110,7 +111,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
     assert(
         strncmp(

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMaps_Names_maxLen.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMaps_Names_maxLen.c
@@ -18,6 +18,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -37,7 +38,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -71,7 +72,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -120,7 +121,7 @@ main(int argc, char** argv)
         "cdef0123456789abcdef0123");
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -131,11 +132,11 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "linked_map_codeletset_Names_maxLen");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMaps_duplicate_linked_map_name.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMaps_duplicate_linked_map_name.c
@@ -18,6 +18,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -36,7 +37,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -137,7 +138,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMaps_duplicate_map_name.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMaps_duplicate_map_name.c
@@ -17,6 +17,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -137,7 +138,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMaps_max.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMaps_max.c
@@ -18,6 +18,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -117,7 +118,7 @@ main(int argc, char** argv)
     }
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -128,11 +129,11 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "max_linked_map_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMaps_maxExceeded.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMaps_maxExceeded.c
@@ -20,6 +20,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -38,7 +39,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -72,7 +73,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -120,7 +121,7 @@ main(int argc, char** argv)
     }
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[1].codelet_path,
         JBPF_PATH_LEN,
@@ -131,7 +132,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[1].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_Name_maxLen.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_Name_maxLen.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -82,11 +83,11 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "simple_output_shared_maxLen_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_Name_notSet.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_Name_notSet.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -75,7 +76,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_output_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_Name_tooLong.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_Name_tooLong.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_output_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_Serde_maxLen.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_Serde_maxLen.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -37,7 +38,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -86,7 +87,7 @@ main(int argc, char** argv)
     // Load the codeletset
     // Note that the laod will fail because the Serde is not known, but it is checking that the message shows that the
     // file does not exist, as opposed to being too long
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
     assert(
         strncmp(

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_Serde_notSet.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_Serde_notSet.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_output_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_Serde_tooLong.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_Serde_tooLong.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -79,7 +80,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_output_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_Serde_unknown.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_Serde_unknown.c
@@ -14,6 +14,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "simple_output_shared");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_map_unknown.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_map_unknown.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -79,7 +80,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_mismatch.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_mismatch.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -64,7 +65,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -77,7 +78,7 @@ main(int argc, char** argv)
     int rety = jbpf_codeletset_load(&codeletset_req_c1, &err_msg);
     printf("Return code: %d\n", rety);
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Cleanup and stop

--- a/jbpf_tests/functional/request_validation/codelet_OutChannel_null.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannel_null.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -68,7 +69,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -79,7 +80,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_OutChannels_max.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannels_max.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -32,7 +33,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -66,7 +67,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -76,11 +77,11 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletsets
     strcpy(codeletset_unload_req_c1.codeletset_id.name, "max_output_shared_codeletset");
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codelet_OutChannels_maxExceeded.c
+++ b/jbpf_tests/functional/request_validation/codelet_OutChannels_maxExceeded.c
@@ -17,6 +17,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -79,7 +80,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_Path_maxLen.c
+++ b/jbpf_tests/functional/request_validation/codelet_Path_maxLen.c
@@ -17,6 +17,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -35,7 +36,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_Path_notKnown.c
+++ b/jbpf_tests/functional/request_validation/codelet_Path_notKnown.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -60,7 +61,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // set an Unknown codelet_path
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -71,7 +72,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_Path_notSet.c
+++ b/jbpf_tests/functional/request_validation/codelet_Path_notSet.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -33,7 +34,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -65,7 +66,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_Path_tooLong.c
+++ b/jbpf_tests/functional/request_validation/codelet_Path_tooLong.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -68,7 +69,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_badObject.c
+++ b/jbpf_tests/functional/request_validation/codelet_badObject.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 int
 main(int argc, char** argv)
@@ -29,7 +30,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -62,7 +63,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].codelet_name, "bad_object_codeletset");
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_CREATION_FAIL);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_hook_notSet.c
+++ b/jbpf_tests/functional/request_validation/codelet_hook_notSet.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -33,7 +34,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -59,7 +60,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -69,7 +70,7 @@ main(int argc, char** argv)
     // DO NOT SET hook_name strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_hook_tooLong.c
+++ b/jbpf_tests/functional/request_validation/codelet_hook_tooLong.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -33,7 +34,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -59,7 +60,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -74,7 +75,7 @@ main(int argc, char** argv)
         codeletset_req_c1.codelet_descriptor[0].hook_name[i] = hook_name_too_long[i];
     }
 
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_hook_unknown.c
+++ b/jbpf_tests/functional/request_validation/codelet_hook_unknown.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -33,7 +34,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -59,7 +60,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -71,7 +72,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "UnknownHook");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_HOOK_NOT_EXIST);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_HOOK_NOT_EXIST);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_name_maxLen.c
+++ b/jbpf_tests/functional/request_validation/codelet_name_maxLen.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -60,7 +61,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -76,11 +77,11 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Unload the codeletset
     codeletset_unload_req_c1.codeletset_id = codeletset_req_c1.codeletset_id;
-    assert(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(&codeletset_unload_req_c1, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // Stop
     jbpf_stop();

--- a/jbpf_tests/functional/request_validation/codelet_name_notSet.c
+++ b/jbpf_tests/functional/request_validation/codelet_name_notSet.c
@@ -15,6 +15,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -33,7 +34,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -59,7 +60,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -70,7 +71,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/request_validation/codelet_name_tooLong.c
+++ b/jbpf_tests/functional/request_validation/codelet_name_tooLong.c
@@ -16,6 +16,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 jbpf_io_stream_id_t stream_id_c1 = {
     .id = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}};
@@ -34,7 +35,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();
@@ -60,7 +61,7 @@ main(int argc, char** argv)
     codeletset_req_c1.codelet_descriptor[0].num_linked_maps = 0;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         codeletset_req_c1.codelet_descriptor[0].codelet_path,
         JBPF_PATH_LEN,
@@ -75,7 +76,7 @@ main(int argc, char** argv)
     strcpy(codeletset_req_c1.codelet_descriptor[0].hook_name, "test1");
 
     // Load the codeletset
-    assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    __assert__(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
     assert(strlen(err_msg.err_msg) > 0);
 
     // Stop

--- a/jbpf_tests/functional/verifier_extensions/all_maps.cpp
+++ b/jbpf_tests/functional/verifier_extensions/all_maps.cpp
@@ -36,6 +36,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 
@@ -82,7 +83,7 @@ main(int argc, char** argv)
         new_map_type.is_array = false;
         new_map_type.value_type = EbpfMapValueType::ANY;
         printf("Registering new_map1\n");
-        assert(jbpf_verifier_register_map_type(map_id, new_map_type) >= 0);
+        __assert__(jbpf_verifier_register_map_type(map_id, new_map_type) >= 0);
         map_id++;
     }
 
@@ -94,7 +95,7 @@ main(int argc, char** argv)
         new_map_type.is_array = true;
         new_map_type.value_type = EbpfMapValueType::ANY;
         printf("Registering new_map2\n");
-        assert(jbpf_verifier_register_map_type(map_id, new_map_type) >= 0);
+        __assert__(jbpf_verifier_register_map_type(map_id, new_map_type) >= 0);
         map_id++;
     }
 
@@ -106,7 +107,7 @@ main(int argc, char** argv)
         new_map_type.is_array = true;
         new_map_type.value_type = EbpfMapValueType::MAP;
         printf("Registering new_map3\n");
-        assert(jbpf_verifier_register_map_type(map_id, new_map_type) >= 0);
+        __assert__(jbpf_verifier_register_map_type(map_id, new_map_type) >= 0);
         map_id++;
     }
 
@@ -118,7 +119,7 @@ main(int argc, char** argv)
         new_map_type.is_array = true;
         new_map_type.value_type = EbpfMapValueType::MAP;
         printf("Registering new_map4\n");
-        assert(jbpf_verifier_register_map_type(map_id, new_map_type) >= 0);
+        __assert__(jbpf_verifier_register_map_type(map_id, new_map_type) >= 0);
         map_id++;
     }
 
@@ -131,7 +132,7 @@ main(int argc, char** argv)
         new_map_type.is_array = false;
         new_map_type.value_type = EbpfMapValueType::PROGRAM;
         printf("Registering new_map5\n");
-        assert(jbpf_verifier_register_map_type(map_id, new_map_type) < 0);
+        __assert__(jbpf_verifier_register_map_type(map_id, new_map_type) < 0);
     }
 
     // map 6
@@ -143,7 +144,7 @@ main(int argc, char** argv)
         new_map_type.is_array = true;
         new_map_type.value_type = EbpfMapValueType::PROGRAM;
         printf("Registering new_map6\n");
-        assert(jbpf_verifier_register_map_type(map_id, new_map_type) < 0);
+        __assert__(jbpf_verifier_register_map_type(map_id, new_map_type) < 0);
     }
 
     // helper func
@@ -152,7 +153,7 @@ main(int argc, char** argv)
 
         jbpf_helper_func_def_t helper_func = {"new_helper_func", helper_id, (jbpf_helper_func_t)helper_func_1};
         helper_func.reloc_id = helper_id;
-        assert(jbpf_register_helper_function(helper_func) == 0); // new registration
+        __assert__(jbpf_register_helper_function(helper_func) == 0); // new registration
 
         // prototype for the function
         static const struct EbpfHelperPrototype helper_proto = {
@@ -166,7 +167,7 @@ main(int argc, char** argv)
         jbpf_verifier_register_helper(helper_id, helper_proto);
     }
 
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     char codelet_path[JBPF_PATH_LEN];
     snprintf(codelet_path, JBPF_PATH_LEN, "%s/jbpf_tests/test_files/codelets/helper_funcs/all_maps.o", jbpf_path);
 

--- a/jbpf_tests/functional/verifier_extensions/helper_func_all_argTypes.cpp
+++ b/jbpf_tests/functional/verifier_extensions/helper_func_all_argTypes.cpp
@@ -30,6 +30,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 
@@ -207,7 +208,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     sem_init(&sem, 0, 0);
 
@@ -223,7 +224,7 @@ main(int argc, char** argv)
     {
         jbpf_helper_func_def_t helper_func = {"new_helper_func", helper_id, (jbpf_helper_func_t)helper_func_1};
         helper_func.reloc_id = helper_id;
-        assert(jbpf_register_helper_function(helper_func) == 0); // new registration
+        __assert__(jbpf_register_helper_function(helper_func) == 0); // new registration
 
         // prototype for the function
         static const struct EbpfHelperPrototype helper_proto = {
@@ -248,7 +249,7 @@ main(int argc, char** argv)
     {
         jbpf_helper_func_def_t helper_func = {"new_helper_func", helper_id, (jbpf_helper_func_t)helper_func_2};
         helper_func.reloc_id = helper_id;
-        assert(jbpf_register_helper_function(helper_func) == 0); // new registration
+        __assert__(jbpf_register_helper_function(helper_func) == 0); // new registration
 
         // prototype for the function
         static const struct EbpfHelperPrototype helper_proto = {
@@ -274,7 +275,7 @@ main(int argc, char** argv)
     {
         jbpf_helper_func_def_t helper_func = {"new_helper_func", helper_id, (jbpf_helper_func_t)helper_func_3};
         helper_func.reloc_id = helper_id;
-        assert(jbpf_register_helper_function(helper_func) == 0); // new registration
+        __assert__(jbpf_register_helper_function(helper_func) == 0); // new registration
 
         // prototype for the function
         static const struct EbpfHelperPrototype helper_proto = {
@@ -300,7 +301,7 @@ main(int argc, char** argv)
     {
         jbpf_helper_func_def_t helper_func = {"new_helper_func", helper_id, (jbpf_helper_func_t)helper_func_4};
         helper_func.reloc_id = helper_id;
-        assert(jbpf_register_helper_function(helper_func) == 0); // new registration
+        __assert__(jbpf_register_helper_function(helper_func) == 0); // new registration
 
         // prototype for the function
         static const struct EbpfHelperPrototype helper_proto = {
@@ -326,7 +327,7 @@ main(int argc, char** argv)
     {
         jbpf_helper_func_def_t helper_func = {"new_helper_func", helper_id, (jbpf_helper_func_t)helper_func_5};
         helper_func.reloc_id = helper_id;
-        assert(jbpf_register_helper_function(helper_func) == 0); // new registration
+        __assert__(jbpf_register_helper_function(helper_func) == 0); // new registration
 
         // prototype for the function
         static const struct EbpfHelperPrototype helper_proto = {
@@ -400,7 +401,7 @@ main(int argc, char** argv)
     ch->has_serde = false;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         cod->codelet_path,
         JBPF_PATH_LEN,
@@ -456,7 +457,7 @@ main(int argc, char** argv)
     }
 
     // Load the codeletset. Loading should fail
-    assert(jbpf_codeletset_load(codset, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(codset, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Call hook
     my_new_jbpf_ctx ctx = {0};
@@ -477,7 +478,7 @@ main(int argc, char** argv)
     sem_wait(&sem);
 
     codset_ul->codeletset_id = codset->codeletset_id;
-    assert(jbpf_codeletset_unload(codset_ul, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(codset_ul, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // We reset the helper functions. The codelet should fail to load again
     jbpf_reset_helper_functions();

--- a/jbpf_tests/functional/verifier_extensions/helper_func_max.cpp
+++ b/jbpf_tests/functional/verifier_extensions/helper_func_max.cpp
@@ -36,6 +36,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 
@@ -108,7 +109,7 @@ main(int argc, char** argv)
 
     config.lcm_ipc_config.has_lcm_ipc_thread = false;
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     sem_init(&sem, 0, 0);
 
@@ -123,10 +124,10 @@ main(int argc, char** argv)
             "new_helper_func", helper_id, (jbpf_helper_func_t)new_helper_implementation};
         helper_func.reloc_id = helper_id;
         if (helper_id < MAX_HELPER_FUNC) {
-            assert(jbpf_register_helper_function(helper_func) == 0); // new registration
+            __assert__(jbpf_register_helper_function(helper_func) == 0); // new registration
         } else {
             // check that we can't register more than MAX_HELPER_FUNC
-            assert(jbpf_register_helper_function(helper_func) < 0); // failure
+            __assert__(jbpf_register_helper_function(helper_func) < 0); // failure
         }
     }
 
@@ -168,7 +169,7 @@ main(int argc, char** argv)
     ch->has_serde = false;
 
     // The path of the codelet
-    assert(jbpf_path != NULL);
+    __assert__(jbpf_path != NULL);
     snprintf(
         cod->codelet_path,
         JBPF_PATH_LEN,
@@ -183,7 +184,7 @@ main(int argc, char** argv)
     assert(result.verification_pass);
 
     // Load the codeletset. Loading should fail
-    assert(jbpf_codeletset_load(codset, NULL) == JBPF_CODELET_LOAD_SUCCESS);
+    __assert__(jbpf_codeletset_load(codset, NULL) == JBPF_CODELET_LOAD_SUCCESS);
 
     // Call hook
     for (int i = CUSTOM_HELPER_START_ID; i < MAX_HELPER_FUNC; i++) {
@@ -199,7 +200,7 @@ main(int argc, char** argv)
     sem_wait(&sem);
 
     codset_ul->codeletset_id = codset->codeletset_id;
-    assert(jbpf_codeletset_unload(codset_ul, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
+    __assert__(jbpf_codeletset_unload(codset_ul, NULL) == JBPF_CODELET_UNLOAD_SUCCESS);
 
     // We reset the helper functions. The codelet should fail to load again
     jbpf_reset_helper_functions();

--- a/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_loader_e2e_test.cpp
+++ b/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_loader_e2e_test.cpp
@@ -23,6 +23,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define NUM_ITERATIONS 5
 
@@ -90,7 +91,7 @@ run_jbpf_agent()
     jbpf_set_default_config_options(&config);
     sem_init(&sem, 0, 0);
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // The thread will be calling hooks, so we need to register it
     jbpf_register_thread();

--- a/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_loader_test_with_linked_map.cpp
+++ b/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_loader_test_with_linked_map.cpp
@@ -27,6 +27,7 @@
 
 // Contains the struct and hook definitions
 #include "jbpf_test_def.h"
+#include "jbpf_test_lib.h"
 
 #define LCM_CLI_SEM_NAME "/jbpf_lcm_cli_loader_e2e_standalone_sem"
 #define LCM_CLI_AGENT_SEM_NAME "/jbpf_lcm_cli_loader_e2e_agent_sem"
@@ -62,7 +63,7 @@ run_jbpf_agent()
     jbpf_set_default_config_options(&config);
     sem_init(&sem, 0, 0);
 
-    assert(jbpf_init(&config) == 0);
+    __assert__(jbpf_init(&config) == 0);
 
     // Register jbpf thread
     jbpf_register_thread();

--- a/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_stream_id_test.cpp
+++ b/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_stream_id_test.cpp
@@ -3,6 +3,7 @@
 
 #include "stream_id.hpp"
 #include "jbpf_lcm_api.h"
+#include "jbpf_test_lib.h"
 
 struct from_hex_test_case_t
 {
@@ -63,7 +64,7 @@ main(int argc, char** argv)
     // All the below test cases should fail to generate a stream id
     for (auto hex : error_from_hex_test) {
         jbpf_io_stream_id_t stream_id;
-        assert(jbpf_lcm_cli::stream_id::from_hex(hex, &stream_id));
+        __assert__(jbpf_lcm_cli::stream_id::from_hex(hex, &stream_id));
     }
 
     // All the below test cases should generate a stream id
@@ -78,7 +79,7 @@ main(int argc, char** argv)
     // All the below test cases should fail to generate a stream id
     for (auto seed : error_generate_from_strings_test) {
         jbpf_io_stream_id_t stream_id;
-        assert(jbpf_lcm_cli::stream_id::generate_from_strings(seed, &stream_id));
+        __assert__(jbpf_lcm_cli::stream_id::generate_from_strings(seed, &stream_id));
     }
 
     return 0;

--- a/jbpf_tests/unit_tests/helper_functions/jbpf_helper_utils_test.c
+++ b/jbpf_tests/unit_tests/helper_functions/jbpf_helper_utils_test.c
@@ -32,12 +32,13 @@
 #include <assert.h>
 #include <math.h>
 #include "jbpf_helper_utils.h"
+#include "jbpf_test_lib.h"
 
 void
 test_fixedpt_fromint(void)
 {
     fixedpt result = fixedpt_fromint(5);
-    assert(result == (5 << FIXEDPT_FBITS)); // 5 shifted left by FIXEDPT_FBITS
+    __assert__(result == (5 << FIXEDPT_FBITS)); // 5 shifted left by FIXEDPT_FBITS
     printf("test_fixedpt_fromint passed\n");
 }
 
@@ -46,7 +47,7 @@ test_fixedpt_toint(void)
 {
     fixedpt input = (3 << FIXEDPT_FBITS) + (1 << (FIXEDPT_FBITS - 1)); // Should round down to 3
     int result = fixedpt_toint(input);
-    assert(result == 3);
+    __assert__(result == 3);
     printf("test_fixedpt_toint passed\n");
 }
 
@@ -56,7 +57,7 @@ test_fixedpt_add(void)
     fixedpt a = 5 << FIXEDPT_FBITS;
     fixedpt b = 3 << FIXEDPT_FBITS;
     fixedpt result = fixedpt_add(a, b);
-    assert(result == 8 << FIXEDPT_FBITS);
+    __assert__(result == 8 << FIXEDPT_FBITS);
     printf("test_fixedpt_add passed\n");
 }
 
@@ -66,7 +67,7 @@ test_fixedpt_sub(void)
     fixedpt a = 5 << FIXEDPT_FBITS;
     fixedpt b = 3 << FIXEDPT_FBITS;
     fixedpt result = fixedpt_sub(a, b);
-    assert(result == 2 << FIXEDPT_FBITS);
+    __assert__(result == 2 << FIXEDPT_FBITS);
     printf("test_fixedpt_sub passed\n");
 }
 
@@ -76,7 +77,7 @@ test_fixedpt_mul(void)
     fixedpt a = 5 << FIXEDPT_FBITS;
     fixedpt b = 3 << FIXEDPT_FBITS;
     fixedpt result = fixedpt_mul(a, b);
-    assert(result == 15 << FIXEDPT_FBITS); // 5 * 3 = 15, scaled by FIXEDPT_FBITS
+    __assert__(result == 15 << FIXEDPT_FBITS); // 5 * 3 = 15, scaled by FIXEDPT_FBITS
     printf("test_fixedpt_mul passed\n");
 }
 
@@ -86,7 +87,7 @@ test_fixedpt_div(void)
     fixedpt a = 6 << FIXEDPT_FBITS;
     fixedpt b = 3 << FIXEDPT_FBITS;
     fixedpt result = fixedpt_div(a, b);
-    assert(result == 2 << FIXEDPT_FBITS); // 6 / 3 = 2, scaled by FIXEDPT_FBITS
+    __assert__(result == 2 << FIXEDPT_FBITS); // 6 / 3 = 2, scaled by FIXEDPT_FBITS
     printf("test_fixedpt_div passed\n");
 }
 
@@ -95,7 +96,7 @@ test_fixedpt_fracpart(void)
 {
     fixedpt a = (5 << FIXEDPT_FBITS) + (1 << (FIXEDPT_FBITS - 2)); // a = 5.25
     fixedpt frac = fixedpt_fracpart(a);
-    assert(frac == (1 << (FIXEDPT_FBITS - 2))); // Fraction part should be 0.25
+    __assert__(frac == (1 << (FIXEDPT_FBITS - 2))); // Fraction part should be 0.25
     printf("test_fixedpt_fracpart passed\n");
 }
 
@@ -105,7 +106,7 @@ test_fixedpt_str(void)
     fixedpt a = (5 << FIXEDPT_FBITS) + (1 << (FIXEDPT_FBITS - 2)); // a = 5.25
     char str[25];
     fixedpt_str(a, str, -1); // Default number of decimal places
-    assert(strcmp(str, "5.25") == 0);
+    __assert__(strcmp(str, "5.25") == 0);
     printf("test_fixedpt_str passed\n");
 }
 
@@ -114,7 +115,7 @@ test_fixedpt_cstr(void)
 {
     fixedpt a = (5 << FIXEDPT_FBITS) + (1 << (FIXEDPT_FBITS - 2)); // a = 5.25
     char* result = fixedpt_cstr(a, -1);
-    assert(strcmp(result, "5.25") == 0);
+    __assert__(strcmp(result, "5.25") == 0);
     printf("test_fixedpt_cstr passed\n");
 }
 
@@ -123,7 +124,7 @@ test_fixedpt_sqrt(void)
 {
     fixedpt a = (4 << FIXEDPT_FBITS); // 4 in fixedpt
     fixedpt result = fixedpt_sqrt(a);
-    assert(result == (2 << FIXEDPT_FBITS)); // sqrt(4) = 2
+    __assert__(result == (2 << FIXEDPT_FBITS)); // sqrt(4) = 2
     printf("test_fixedpt_sqrt passed\n");
 }
 
@@ -132,8 +133,8 @@ test_fixedpt_sin(void)
 {
     fixedpt a = FIXEDPT_PI / 2; // 90 degrees in fixedpt
     fixedpt result = fixedpt_sin(a);
-    // assert(result == FIXEDPT_ONE); // sin(90 degrees) = 1
-    assert(fixedpt_abs(result - FIXEDPT_ONE) < FIXEDPT_EPSILON); // Allow small epsilon error
+    // __assert__(result == FIXEDPT_ONE); // sin(90 degrees) = 1
+    __assert__(fixedpt_abs(result - FIXEDPT_ONE) < FIXEDPT_EPSILON); // Allow small epsilon error
     printf("test_fixedpt_sin passed\n");
 }
 
@@ -142,8 +143,8 @@ test_fixedpt_cos(void)
 {
     fixedpt a = FIXEDPT_PI; // 180 degrees in fixedpt
     fixedpt result = fixedpt_cos(a);
-    // assert(result == -FIXEDPT_ONE); // cos(180 degrees) = -1
-    assert(fixedpt_abs(result - -FIXEDPT_ONE) < FIXEDPT_EPSILON); // Allow small epsilon error
+    // __assert__(result == -FIXEDPT_ONE); // cos(180 degrees) = -1
+    __assert__(fixedpt_abs(result - -FIXEDPT_ONE) < FIXEDPT_EPSILON); // Allow small epsilon error
     printf("test_fixedpt_cos passed\n");
 }
 
@@ -152,7 +153,7 @@ test_fixedpt_tan(void)
 {
     fixedpt a = FIXEDPT_PI / 4; // 45 degrees in fixedpt
     fixedpt result = fixedpt_tan(a);
-    assert(result == FIXEDPT_ONE); // tan(45 degrees) = 1
+    __assert__(result == FIXEDPT_ONE); // tan(45 degrees) = 1
     printf("test_fixedpt_tan passed\n");
 }
 
@@ -161,7 +162,7 @@ test_fixedpt_exp(void)
 {
     fixedpt a = fixedpt_rconst(1); // e^1
     fixedpt result = fixedpt_exp(a);
-    assert(result == fixedpt_rconst(2.7182818284590452354)); // Approximation of e
+    __assert__(result == fixedpt_rconst(2.7182818284590452354)); // Approximation of e
     printf("test_fixedpt_exp passed\n");
 }
 
@@ -170,7 +171,7 @@ test_fixedpt_ln(void)
 {
     fixedpt a = fixedpt_rconst(2.7182818284590452354); // ln(e)
     fixedpt result = fixedpt_ln(a);
-    assert(result == fixedpt_rconst(1)); // ln(e) = 1
+    __assert__(result == fixedpt_rconst(1)); // ln(e) = 1
     printf("test_fixedpt_ln passed\n");
 }
 
@@ -180,8 +181,8 @@ test_fixedpt_log(void)
     fixedpt a = fixedpt_rconst(8); // log2(8)
     fixedpt base = fixedpt_rconst(2);
     fixedpt result = fixedpt_log(a, base);
-    // assert(result == fixedpt_rconst(3)); // log2(8) = 3
-    assert(fixedpt_abs(result - fixedpt_rconst(3)) < FIXEDPT_EPSILON); // Allow small epsilon error
+    // __assert__(result == fixedpt_rconst(3)); // log2(8) = 3
+    __assert__(fixedpt_abs(result - fixedpt_rconst(3)) < FIXEDPT_EPSILON); // Allow small epsilon error
     printf("test_fixedpt_log passed\n");
 }
 
@@ -190,10 +191,10 @@ test_fixedpt_abs(void)
 {
     fixedpt a = fixedpt_rconst(-5); // -5 in fixedpt
     fixedpt result = fixedpt_abs(a);
-    assert(result == fixedpt_rconst(5)); // Absolute value should be 5
+    __assert__(result == fixedpt_rconst(5)); // Absolute value should be 5
     fixedpt b = fixedpt_rconst(3);       // 3 in fixedpt
     fixedpt result2 = fixedpt_abs(b);
-    assert(result2 == fixedpt_rconst(3)); // Absolute value should be 3
+    __assert__(result2 == fixedpt_rconst(3)); // Absolute value should be 3
     printf("test_fixedpt_abs passed\n");
 }
 
@@ -204,8 +205,8 @@ test_fixedpt_pow(void)
     fixedpt exp = fixedpt_rconst(3);  // 3 in fixedpt
     fixedpt result = fixedpt_pow(base, exp);
     // allow small epsilon error
-    assert(fixedpt_abs(result - fixedpt_rconst(8)) < FIXEDPT_EPSILON); // 2^3 = 8
-    // assert(result == fixedpt_rconst(8)); // 2^3 = 8
+    __assert__(fixedpt_abs(result - fixedpt_rconst(8)) < FIXEDPT_EPSILON); // 2^3 = 8
+    // __assert__(result == fixedpt_rconst(8)); // 2^3 = 8
     printf("test_fixedpt_pow passed\n");
 }
 
@@ -214,7 +215,7 @@ test_fixed_to_float(void)
 {
     fixedptd a = fixedpt_rconst(5.25); // 5.25 in fixedpt
     float result = fixed_to_float(a);
-    assert(fabs(result - 5.25) < 0.0001); // Allow small epsilon error
+    __assert__(fabs(result - 5.25) < 0.0001); // Allow small epsilon error
     printf("test_fixed_to_float passed\n");
 }
 
@@ -223,7 +224,7 @@ test_fixed_to_double(void)
 {
     fixedptd a = fixedpt_rconst(5.25); // 5.25 in fixedpt
     double result = fixed_to_double(a);
-    assert(fabs(result - 5.25) < 0.0001); // Allow small epsilon error
+    __assert__(fabs(result - 5.25) < 0.0001); // Allow small epsilon error
     printf("test_fixed_to_double passed\n");
 }
 
@@ -232,7 +233,7 @@ test_float_to_fixed(void)
 {
     float a = 5.25; // 5.25 in float
     fixedpt result = float_to_fixed(a);
-    assert(result == fixedpt_rconst(5.25)); // Should be equal to fixedpt representation of 5.25
+    __assert__(result == fixedpt_rconst(5.25)); // Should be equal to fixedpt representation of 5.25
     printf("test_float_to_fixed passed\n");
 }
 
@@ -241,7 +242,7 @@ test_double_to_fixed(void)
 {
     double a = 5.25; // 5.25 in double
     fixedpt result = double_to_fixed(a);
-    assert(result == fixedpt_rconst(5.25)); // Should be equal to fixedpt representation of 5.25
+    __assert__(result == fixedpt_rconst(5.25)); // Should be equal to fixedpt representation of 5.25
     printf("test_double_to_fixed passed\n");
 }
 
@@ -251,7 +252,7 @@ test_convert_float_to_fixed_and_back(void)
     float a = 5.25; // 5.25 in float
     fixedpt fixed_value = float_to_fixed(a);
     float result = fixed_to_float(fixed_value);
-    assert(fabs(result - a) < 0.0001); // Allow small epsilon error
+    __assert__(fabs(result - a) < 0.0001); // Allow small epsilon error
     printf("test_convert_float_to_fixed_and_back passed\n");
 }
 
@@ -261,7 +262,7 @@ test_convert_double_to_fixed_and_back(void)
     double a = 5.25; // 5.25 in double
     fixedpt fixed_value = double_to_fixed(a);
     double result = fixed_to_double(fixed_value);
-    assert(fabs(result - a) < 0.0001); // Allow small epsilon error
+    __assert__(fabs(result - a) < 0.0001); // Allow small epsilon error
     printf("test_convert_double_to_fixed_and_back passed\n");
 }
 
@@ -271,7 +272,7 @@ test_convert_fixed_to_float_and_back(void)
     fixedpt a = fixedpt_rconst(5.25); // 5.25 in fixedpt
     float float_value = fixed_to_float(a);
     fixedpt result = float_to_fixed(float_value);
-    assert(result == a); // Should be equal to original fixedpt value
+    __assert__(result == a); // Should be equal to original fixedpt value
     printf("test_convert_fixed_to_float_and_back passed\n");
 }
 
@@ -281,7 +282,7 @@ test_convert_fixed_to_double_and_back(void)
     fixedpt a = fixedpt_rconst(5.25); // 5.25 in fixedpt
     double double_value = fixed_to_double(a);
     fixedpt result = double_to_fixed(double_value);
-    assert(result == a); // Should be equal to original fixedpt value
+    __assert__(result == a); // Should be equal to original fixedpt value
     printf("test_convert_fixed_to_double_and_back passed\n");
 }
 
@@ -298,7 +299,7 @@ test_convert_float_to_fixed_and_do_some_math_and_then_convert_back(void)
     // (2.25 + 2 - 1) * 2 / 0.6 = 10.83333
     float final_result = fixed_to_float(result);
     // precision loss is allowed
-    assert(fabs(final_result - 10.8333) < 0.1);
+    __assert__(fabs(final_result - 10.8333) < 0.1);
     printf("test_convert_float_to_fixed_and_do_some_math_and_then_convert_back passed\n");
 }
 
@@ -315,7 +316,7 @@ test_convert_double_to_fixed_and_do_some_math_and_then_convert_back(void)
     // (1.345 + 2 - 1) * 2 / 1.5 = 3.1266666
     double final_result = fixed_to_double(result);
     // precision loss is allowed
-    assert(fabs(final_result - 3.126) < 0.001);
+    __assert__(fabs(final_result - 3.126) < 0.001);
     printf("test_convert_double_to_fixed_and_do_some_math_and_then_convert_back passed\n");
 }
 

--- a/jbpf_tests/unit_tests/io_mem/io_mem_unit_test.c
+++ b/jbpf_tests/unit_tests/io_mem/io_mem_unit_test.c
@@ -237,12 +237,12 @@ test_jbpf_get_mempool_size_valid(void** state)
         mbuf[i] = jbpf_mbuf_alloc(mempool);
         assert(mbuf != NULL);
         assert(mbuf[i]->ref_cnt == 1);
-        assert(jbpf_get_mempool_size(mempool) == size - i - 1);
+        __assert__(jbpf_get_mempool_size(mempool) == size - i - 1);
     }
     for (int i = 0; i < size; i++) {
         jbpf_mbuf_free(mbuf[i], false);
         assert(mbuf[i]->ref_cnt == 0);
-        assert(jbpf_get_mempool_size(mempool) == i + 1);
+        __assert__(jbpf_get_mempool_size(mempool) == i + 1);
     }
     free(mbuf);
 }
@@ -266,19 +266,19 @@ test_jbpf_get_mempool_size_valid_shared(void** state)
         assert(mbuf != NULL);
         assert(shared_mbuf[i] != NULL);
         assert(mbuf[i]->ref_cnt == 2);
-        assert(jbpf_get_mempool_size(mempool) == size - i - 1);
+        __assert__(jbpf_get_mempool_size(mempool) == size - i - 1);
     }
     // free one by one - ref cnt should be 1
     for (int i = 0; i < size; i++) {
         jbpf_mbuf_free(mbuf[i], false);
         assert(mbuf[i]->ref_cnt == 1);
-        assert(jbpf_get_mempool_size(mempool) == 0);
+        __assert__(jbpf_get_mempool_size(mempool) == 0);
     }
     // free one by one - ref cnt should be 0, and size should update
     for (int i = 0; i < size; i++) {
         jbpf_mbuf_free(shared_mbuf[i], false);
         assert(shared_mbuf[i]->ref_cnt == 0);
-        assert(jbpf_get_mempool_size(mempool) == i + 1);
+        __assert__(jbpf_get_mempool_size(mempool) == i + 1);
     }
     free(mbuf);
     free(shared_mbuf);

--- a/jbpf_tests/verifier/jbpf_basic_verifier_test.cpp
+++ b/jbpf_tests/verifier/jbpf_basic_verifier_test.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 
 #include "jbpf_verifier.hpp"
+#include "jbpf_test_lib.h"
 
 std::string correct_codelets[] = {
     "/jbpf_tests/test_files/codelets/codelet-control-input/codelet-control-input.o",
@@ -39,7 +40,7 @@ main(int argc, char** argv)
 
     jbpf_verifier_result_t result;
     char* jbpf_path = getenv("JBPF_PATH");
-    assert(jbpf_path != nullptr);
+    __assert__(jbpf_path != nullptr);
 
     // All the below codelets should pass verification
     for (auto codelet : correct_codelets) {

--- a/jbpf_tests/verifier/jbpf_verifier_extension_test.cpp
+++ b/jbpf_tests/verifier/jbpf_verifier_extension_test.cpp
@@ -3,6 +3,7 @@
 #include "jbpf_verifier.hpp"
 #include "jbpf_defs.h"
 #include "jbpf_helper_api_defs_ext.h"
+#include "jbpf_test_lib.h"
 
 // Contains the def extensions for the new program types and helper functions
 #include "jbpf_verifier_extension_defs.h"
@@ -17,7 +18,7 @@ main(int argc, char** argv)
 
     std::string codelet = "/jbpf_tests/test_files/codelets/verifier_extensions/verifier_extensions.o";
 
-    assert(jbpf_path != nullptr);
+    __assert__(jbpf_path != nullptr);
     full_path = std::string(jbpf_path);
     full_path.append(codelet);
 
@@ -31,7 +32,7 @@ main(int argc, char** argv)
     new_map_type.name = "NEW_TYPE";
     new_map_type.is_array = false;
 
-    assert(jbpf_verifier_register_map_type(CUSTOM_MAP_START_ID, new_map_type) >= 0);
+    __assert__(jbpf_verifier_register_map_type(CUSTOM_MAP_START_ID, new_map_type) >= 0);
 
     // The test should still fail
     result = jbpf_verify(full_path.c_str(), nullptr, nullptr);


### PR DESCRIPTION
This PR closes #79 
1. when `-DCMAKE_BUILD_TYPE` is not set, it will be defaulted to `RELEASE`
2. Fixes tests due to `assert` being optimised away in `RELEASE`
3. Defines a macro `__assert__` in `jbpf_test_lib.h` to avoid `assert` being optimised away.

For normal assertions on variables, we should stick to `assert` but for assertions on functions, we should use `__assert__` For example:

```c
__assert__(jbpf_init(&config) == 0);
assert(a_boolean_variable);
``