### PR TITLE
Increase MAX_NUM_HOOKS from 64 to 96

### DIFF
--- a/src/core/jbpf_perf_ext.h
+++ b/src/core/jbpf_perf_ext.h
@@ -19,7 +19,7 @@
 /**
  * @brief Maximum number of hooks
  */
-#define MAX_NUM_HOOKS 64
+#define MAX_NUM_HOOKS 96
 
 /**
  * @brief JBPF performance data structure


### PR DESCRIPTION
The current number of hooks is too low.
Increasing to 96.