### PR TITLE
Refactor run_lcm_subproc by removing memory allocation with new/delete.

### DIFF
--- a/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_loader_e2e_test.cpp
+++ b/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_loader_e2e_test.cpp
@@ -129,33 +129,6 @@ run_jbpf_agent()
     return 0;
 }
 
-jbpf_lcm_cli::loader::load_req_outcome
-run_lcm_subproc(std::vector<std::string> str_args)
-{
-    // loader reads opts from argv using getopts
-    // so we need to reset the getopts global to start from the beginning
-    optind = 1;
-
-    char** args = new char*[str_args.size() + 1];
-    args[0] = new char[inline_bin_arg.length() + 1];
-    strcpy(args[0], inline_bin_arg.c_str());
-    args[0][inline_bin_arg.length()] = '\0';
-
-    for (int i = 0; i < str_args.size(); i++) {
-        args[i + 1] = new char[str_args[i].length() + 1];
-        strcpy(args[i + 1], str_args[i].c_str());
-        args[i + 1][str_args[i].length()] = '\0';
-    }
-
-    auto ret = jbpf_lcm_cli::loader::run_loader(str_args.size() + 1, args);
-
-    for (int i = 0; i < str_args.size() + 1; i++)
-        delete[] args[i];
-    delete[] args;
-
-    return ret;
-}
-
 int
 run_lcm_ipc_loader()
 {
@@ -170,10 +143,12 @@ run_lcm_ipc_loader()
             "${JBPF_PATH}/jbpf_tests/tools/lcm_cli/codeletset_req_c1.yaml")};
 
     // Make a request to load the codeletset
-    assert(run_lcm_subproc(args) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
+    assert(
+        jbpf_lcm_cli::loader::run_lcm_subproc(args, inline_bin_arg) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
 
     // Make a 2nd request to load the codeletSet
-    assert(run_lcm_subproc(args) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
+    assert(
+        jbpf_lcm_cli::loader::run_lcm_subproc(args, inline_bin_arg) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
 
     // Loading was done, so the agent test can move on
     sem_post(lcm_cli_agent_sem);
@@ -191,7 +166,8 @@ run_lcm_ipc_loader()
              "${JBPF_PATH}/jbpf_tests/tools/lcm_cli/codeletset_unload_req_c1.yaml")});
 
     // Make a request to unload an existing codeletset
-    assert(run_lcm_subproc(args) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
+    assert(
+        jbpf_lcm_cli::loader::run_lcm_subproc(args, inline_bin_arg) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
 
     // Make a request to load a codeletset that will fail, due to non-existent hook
     args.clear();
@@ -202,7 +178,8 @@ run_lcm_ipc_loader()
          jbpf_lcm_cli::parser::expand_environment_variables(
              "${JBPF_PATH}/jbpf_tests/tools/lcm_cli/codeletset_req_error.yaml")});
 
-    assert(run_lcm_subproc(args) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_FAILURE);
+    assert(
+        jbpf_lcm_cli::loader::run_lcm_subproc(args, inline_bin_arg) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_FAILURE);
 
     // Make a request to unload a non-existent codeletset
     args.clear();
@@ -213,7 +190,8 @@ run_lcm_ipc_loader()
          jbpf_lcm_cli::parser::expand_environment_variables(
              "${JBPF_PATH}/jbpf_tests/tools/lcm_cli/codeletset_unload_req_error.yaml")});
 
-    assert(run_lcm_subproc(args) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_FAILURE);
+    assert(
+        jbpf_lcm_cli::loader::run_lcm_subproc(args, inline_bin_arg) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_FAILURE);
 
     // Tests are done. Let the agent know that it can terminate
     sem_post(lcm_cli_agent_sem);

--- a/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_loader_test_with_linked_map.cpp
+++ b/jbpf_tests/tools/lcm_cli/jbpf_lcm_cli_loader_test_with_linked_map.cpp
@@ -81,33 +81,6 @@ run_jbpf_agent()
     return 0;
 }
 
-jbpf_lcm_cli::loader::load_req_outcome
-run_lcm_subproc(std::vector<std::string> str_args)
-{
-    // loader reads opts from argv using getopts
-    // so we need to reset the getopts global to start from the beginning
-    optind = 1;
-
-    char** args = new char*[str_args.size() + 1];
-    args[0] = new char[inline_bin_arg.length() + 1];
-    strcpy(args[0], inline_bin_arg.c_str());
-    args[0][inline_bin_arg.length()] = '\0';
-
-    for (int i = 0; i < str_args.size(); i++) {
-        args[i + 1] = new char[str_args[i].length() + 1];
-        strcpy(args[i + 1], str_args[i].c_str());
-        args[i + 1][str_args[i].length()] = '\0';
-    }
-
-    auto ret = jbpf_lcm_cli::loader::run_loader(str_args.size() + 1, args);
-
-    for (int i = 0; i < str_args.size() + 1; i++)
-        delete[] args[i];
-    delete[] args;
-
-    return ret;
-}
-
 int
 run_lcm_ipc_loader()
 {
@@ -122,7 +95,8 @@ run_lcm_ipc_loader()
             "${JBPF_PATH}/jbpf_tests/tools/lcm_cli/codeletset_req_with_linked_map.yaml")};
 
     // Make a request to load the codeletset
-    assert(run_lcm_subproc(args) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
+    assert(
+        jbpf_lcm_cli::loader::run_lcm_subproc(args, inline_bin_arg) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
 
     // Test is done. Let's unload the codeletset
     args.clear();
@@ -134,7 +108,8 @@ run_lcm_ipc_loader()
              "${JBPF_PATH}/jbpf_tests/tools/lcm_cli/codeletset_unload_req_with_linked_map.yaml")});
 
     // Make a request to unload an existing codeletset
-    assert(run_lcm_subproc(args) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
+    assert(
+        jbpf_lcm_cli::loader::run_lcm_subproc(args, inline_bin_arg) == jbpf_lcm_cli::loader::JBPF_LCM_CLI_REQ_SUCCESS);
 
     // Tests are done. Let the agent know that it can terminate
     sem_post(lcm_cli_agent_sem);

--- a/tools/lcm_cli/loader.hpp
+++ b/tools/lcm_cli/loader.hpp
@@ -3,6 +3,9 @@
 #ifndef LOADER_HPP
 #define LOADER_HPP
 
+#include <vector>
+#include <string>
+
 namespace jbpf_lcm_cli {
 namespace loader {
 enum load_req_outcome
@@ -17,6 +20,9 @@ enum load_req_outcome
 
 load_req_outcome
 run_loader(int ac, char** av);
+
+load_req_outcome
+run_lcm_subproc(const std::vector<std::string>& str_args, const std::string& inline_bin_arg);
 } // namespace loader
 } // namespace jbpf_lcm_cli
 


### PR DESCRIPTION
This PR closes #92 

We should almost never use "new " operator in CPP code. We should strive to use the smart pointers or simply not allocate memory to avoid memory leaks. This PR also refactors the function `run_lcm_subproc` as it appears in two places.