### PR TITLE
Fix build/package error in ubuntu22.04

### DIFF
--- a/deploy/mariner.Dockerfile
+++ b/deploy/mariner.Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0
 RUN echo "*** Installing packages"
 RUN tdnf upgrade tdnf --refresh -y
 RUN tdnf -y update
-RUN tdnf -y install build-essential cmake
+RUN tdnf -y install build-essential cmake git
 RUN tdnf -y install yaml-cpp-devel yaml-cpp-static boost-devel gcovr clang python3
 RUN tdnf -y install doxygen
 ## clang-format

--- a/deploy/ubuntu22.04.Dockerfile
+++ b/deploy/ubuntu22.04.Dockerfile
@@ -10,7 +10,7 @@ RUN echo "*** Installing packages"
 RUN apt-get clean && apt-get update && \
     apt-get install -y --no-install-recommends \
         cmake build-essential libboost-dev libboost-program-options-dev \
-        gcovr doxygen libboost-filesystem-dev libasan6 python3 \
+        git gcovr doxygen libboost-filesystem-dev libasan6 python3 \
         clang-format cppcheck clang gcc-multilib libyaml-cpp-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/ubuntu24.04.Dockerfile
+++ b/deploy/ubuntu24.04.Dockerfile
@@ -6,7 +6,7 @@ ENV CPP_CHECK=1
 
 RUN echo "*** Installing packages"
 RUN apt update --fix-missing
-RUN apt install -y cmake build-essential libboost-dev libboost-program-options-dev \
+RUN apt install -y cmake build-essential libboost-dev git libboost-program-options-dev \
     gcovr doxygen libboost-filesystem-dev libasan6 python3
 
 RUN apt install -y clang-format cppcheck


### PR DESCRIPTION
This PR:
1. fixes the docker build problem emerging at ubuntu22.04 (see errors below)
2. removes `wget` from ubuntu22 and 24 since it is not needed.
3. adds ` --no-cache` to docker build command in github action to avoid docker uses the old caching layers.

> 10 3.314 Get:45 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 llvm-14-tools amd64 1:14.0.0-1ubuntu1.1 [404 kB]
10 3.318 Get:46 http://archive.ubuntu.com/ubuntu jammy/universe amd64 libz3-dev amd64 4.8.12-1 [72.2 kB]
10 3.319 Get:47 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 llvm-14-dev amd64 1:14.0.0-1ubuntu1.1 [37.8 MB]
10 4.067 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-i386_2.35-0ubuntu3.10_amd64.deb  404  Not Found [IP: 91.189.91.83 80]
10 4.067 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dev-i386_2.35-0ubuntu3.10_amd64.deb  404  Not Found [IP: 91.189.91.83 80]
10 4.067 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-x32_2.35-0ubuntu3.10_amd64.deb  404  Not Found [IP: 91.189.91.83 80]
10 4.067 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dev-x32_2.35-0ubuntu3.10_amd64.deb  404  Not Found [IP: 91.189.91.83 80]
10 4.067 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
10 4.067 Fetched 85.8 MB in 3s (31.2 MB/s)
10 ERROR: process "/bin/bash -c apt install -y clang gcc-multilib" did not complete successfully: exit code: 100
```
