### PR TITLE
Fix ubuntu22 and 24 builds: certificates and https

### DIFF
--- a/deploy/ubuntu22.04.Dockerfile
+++ b/deploy/ubuntu22.04.Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && \
 RUN sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g' /etc/apt/sources.list && \
     sed -i 's|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list
 
+RUN apt-get update --allow-releaseinfo-change
+
 # --- Install required packages ---
 RUN echo "*** Installing packages" && \
     apt-get update --fix-missing && \

--- a/deploy/ubuntu22.04.Dockerfile
+++ b/deploy/ubuntu22.04.Dockerfile
@@ -16,7 +16,7 @@ RUN sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g' /etc/apt/s
 
 # --- Install required packages ---
 RUN echo "*** Installing packages" && \
-    apt-get update && \
+    apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
         cmake \
         build-essential \

--- a/deploy/ubuntu22.04.Dockerfile
+++ b/deploy/ubuntu22.04.Dockerfile
@@ -5,15 +5,37 @@ SHELL ["/bin/bash", "-c"]
 ENV CLANG_FORMAT_CHECK=1
 ENV CPP_CHECK=1
 
-RUN echo "*** Installing packages"
+# --- Bootstrap system certificates before switching to HTTPS ---
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get clean && apt-get update && \
+# --- Use HTTPS for all Ubuntu mirrors ---
+RUN sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list
+
+# --- Install required packages ---
+RUN echo "*** Installing packages" && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
-        cmake build-essential libboost-dev libboost-program-options-dev \
-        git gcovr doxygen libboost-filesystem-dev libasan6 python3 \
-        clang-format cppcheck clang gcc-multilib libyaml-cpp-dev && \
+        cmake \
+        build-essential \
+        libboost-dev \
+        libboost-program-options-dev \
+        git \
+        gcovr \
+        doxygen \
+        libboost-filesystem-dev \
+        libasan6 \
+        python3 \
+        clang-format \
+        cppcheck \
+        clang \
+        gcc-multilib \
+        libyaml-cpp-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /jbpf
 COPY . /jbpf
+
 ENTRYPOINT ["./helper_build_files/build_jbpf_lib.sh"]

--- a/deploy/ubuntu24.04.Dockerfile
+++ b/deploy/ubuntu24.04.Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
 RUN sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g' /etc/apt/sources.list && \
     sed -i 's|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list
 
+RUN apt-get update --allow-releaseinfo-change
+    
 RUN echo "*** Installing packages" && \
     apt update --fix-missing && \
     apt install -y --no-install-recommends \

--- a/deploy/ubuntu24.04.Dockerfile
+++ b/deploy/ubuntu24.04.Dockerfile
@@ -14,7 +14,7 @@ RUN sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g' /etc/apt/s
     sed -i 's|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list
 
 RUN echo "*** Installing packages" && \
-    apt update && \
+    apt update --fix-missing && \
     apt install -y --no-install-recommends \
         cmake \
         build-essential \

--- a/deploy/ubuntu24.04.Dockerfile
+++ b/deploy/ubuntu24.04.Dockerfile
@@ -4,15 +4,37 @@ ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]
 ENV CPP_CHECK=1
 
-RUN echo "*** Installing packages"
-RUN apt update --fix-missing
-RUN apt install -y cmake build-essential libboost-dev git libboost-program-options-dev \
-    gcovr doxygen libboost-filesystem-dev libasan6 python3
+# --- Bootstrap system certificates before switching to HTTPS ---
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt install -y clang-format cppcheck
-RUN apt install -y clang gcc-multilib
-RUN apt install -y libyaml-cpp-dev
+# Use HTTPS for all Ubuntu mirrors to avoid port 80 firewall issues
+RUN sed -i 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.ubuntu.com|https://security.ubuntu.com|g' /etc/apt/sources.list
+
+RUN echo "*** Installing packages" && \
+    apt update && \
+    apt install -y --no-install-recommends \
+        cmake \
+        build-essential \
+        libboost-dev \
+        git \
+        libboost-program-options-dev \
+        gcovr \
+        doxygen \
+        libboost-filesystem-dev \
+        libasan6 \
+        python3 \
+        clang-format \
+        cppcheck \
+        clang \
+        gcc-multilib \
+        libyaml-cpp-dev && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /jbpf
 COPY . /jbpf
+
 ENTRYPOINT ["./helper_build_files/build_jbpf_lib.sh"]


### PR DESCRIPTION
This PR fixes the ubuntu22 and 24 build problems:
1. HTTPS for mirrors
2. Install system certificates