### PR TITLE
Bugfix: perf time measurement API with invalid times

### DIFF
--- a/jbpf_tests/functional/CMakeLists.txt
+++ b/jbpf_tests/functional/CMakeLists.txt
@@ -31,4 +31,6 @@ add_subdirectory(verifier_extensions)
 add_subdirectory(ctrl_hooks)
 add_subdirectory(helper_functions)
 add_subdirectory(array)
+add_subdirectory(perf)
+
 

--- a/jbpf_tests/functional/perf/CMakeLists.txt
+++ b/jbpf_tests/functional/perf/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+## array tests
+set(PERF_FUNCTIONAL_TESTS ${TESTS_FUNCTIONAL}/perf)
+file(GLOB PERF_FUNCTIONAL_TESTS_SOURCES ${PERF_FUNCTIONAL_TESTS}/*.c)
+set(JBPF_TESTS ${JBPF_TESTS} PARENT_SCOPE)
+# Loop through each test file and create an executable
+foreach(TEST_FILE ${PERF_FUNCTIONAL_TESTS_SOURCES})
+  # Get the filename without the path
+  get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+
+  # Create an executable target for the test
+  add_executable(${TEST_NAME} ${TEST_FILE} ${TESTS_COMMON}/jbpf_test_lib.c) 
+
+  # Link the necessary libraries
+  target_link_libraries(${TEST_NAME} PUBLIC jbpf::core_lib jbpf::logger_lib jbpf::mem_mgmt_lib)
+
+  # Set the include directories
+  target_include_directories(${TEST_NAME} PUBLIC ${JBPF_LIB_HEADER_FILES} ${TEST_HEADER_FILES})
+
+  # Add the test to the list of tests to be executed
+  add_test(NAME FUNCTIONAL/${TEST_NAME} COMMAND ${TEST_NAME})
+
+  # Test coverage
+  list(APPEND JBPF_TESTS FUNCTIONAL/${TEST_NAME})
+  add_clang_format_check(${TEST_NAME} ${TEST_FILE})
+  add_cppcheck(${TEST_NAME} ${TEST_FILE})
+  set(JBPF_TESTS ${JBPF_TESTS} PARENT_SCOPE)
+endforeach()

--- a/jbpf_tests/functional/perf/jbpf_perf_time.c
+++ b/jbpf_tests/functional/perf/jbpf_perf_time.c
@@ -1,0 +1,77 @@
+/*
+ * The purpose of this test is to check the correct functionality of the perf API.
+ *
+ * This test does the following:
+ * 1. It measures the elapsed time using the perf API with both valid and invalid time values.
+ * 2. It checks that the perf API correctly handles invalid time values and does not crash.
+ */
+
+#include <assert.h>
+
+#include "jbpf.h"
+#include "jbpf_perf.h"
+
+#include "jbpf_logging.h"
+
+int
+main(int argc, char* argv[])
+{
+
+    struct jbpf_config config = {0};
+    uint32_t perf_idx, min_time, max_time;
+    struct jbpf_hook test_hook = {
+        .name = "test_hook",
+        .hook_type = JBPF_HOOK_TYPE_MON,
+        .jbpf_perf_active = JBPF_HOOK_PERF_DEFAULT_STATE,
+    };
+
+    jbpf_set_default_config_options(&config);
+
+    assert(jbpf_init(&config) == 0);
+
+    jbpf_init_perf_hook(&test_hook);
+
+    // The thread will be calling jbpf perf functions, so we need to register it
+    jbpf_register_thread();
+
+    perf_idx = get_jbpf_hook_thread_id();
+    assert(perf_idx > 0 && perf_idx < JBPF_MAX_NUM_REG_THREADS); // Ensure the perf index is within bounds
+
+    // Start the perf measurement with a valid time
+    uint64_t start_time = jbpf_measure_start_time();
+    // Simulate some processing
+    usleep(1000); // Sleep for 1ms to simulate processing time
+    uint64_t end_time = jbpf_measure_stop_time();
+
+    // Log the valid time measurement
+    struct jbpf_perf_data* perf_data = jbpf_get_perf_data(&test_hook);
+    assert(perf_data != NULL); // Ensure perf_data is not NULL
+
+    int res = _jbpf_perf_log(perf_data, start_time, end_time);
+    assert(res == 0); // Ensure the logging was successful
+
+    // Check that the valid time measurement was logged correctly
+    assert(perf_data[perf_idx].num > 0);
+    min_time = perf_data[perf_idx].min;
+    max_time = perf_data[perf_idx].max;
+    assert(min_time > 0); // Minimum time should be greater than 0
+    assert(max_time > 0); // Maximum time should be greater than 0
+    for (int i = 0; i < JBPF_NUM_HIST_BINS; i++) {
+        assert(perf_data[perf_idx].hist[i] >= 0); // Histogram bins should not be negative
+    }
+
+    // Now, let's test with an invalid time value
+    uint64_t invalid_start_time = 12345; // Invalid start time
+    uint64_t invalid_end_time = 12345;   // Invalid end time
+    // Attempt to log the invalid time measurement
+    res = _jbpf_perf_log(perf_data, invalid_start_time, invalid_end_time);
+    // Ensure that the logging of invalid time does not crash and returns an error
+    assert(res == -1); // Expecting an error for invalid time
+    // Check that the perf data remains unchanged after invalid logging
+    assert(perf_data[perf_idx].num == 1);        // Should still have the valid measurement logged
+    assert(perf_data[perf_idx].min == min_time); // Minimum should still be the same
+    assert(perf_data[perf_idx].max == max_time); // Maximum should still be the same
+
+    // Stop
+    jbpf_stop();
+}

--- a/jbpf_tests/functional/perf/jbpf_perf_time.c
+++ b/jbpf_tests/functional/perf/jbpf_perf_time.c
@@ -10,8 +10,7 @@
 
 #include "jbpf.h"
 #include "jbpf_perf.h"
-
-#include "jbpf_logging.h"
+#include "jbpf_memory.h"
 
 int
 main(int argc, char* argv[])
@@ -71,6 +70,8 @@ main(int argc, char* argv[])
     assert(perf_data[perf_idx].num == 1);        // Should still have the valid measurement logged
     assert(perf_data[perf_idx].min == min_time); // Minimum should still be the same
     assert(perf_data[perf_idx].max == max_time); // Maximum should still be the same
+
+    jbpf_free_mem(perf_data); // Free the perf data
 
     jbpf_free_perf_hook(&test_hook);
 

--- a/jbpf_tests/functional/perf/jbpf_perf_time.c
+++ b/jbpf_tests/functional/perf/jbpf_perf_time.c
@@ -72,6 +72,8 @@ main(int argc, char* argv[])
     assert(perf_data[perf_idx].min == min_time); // Minimum should still be the same
     assert(perf_data[perf_idx].max == max_time); // Maximum should still be the same
 
+    jbpf_free_perf_hook(&test_hook);
+
     // Stop
     jbpf_stop();
 }

--- a/src/core/jbpf_perf.h
+++ b/src/core/jbpf_perf.h
@@ -108,8 +108,11 @@ extern "C"
 
         et = jbpf_get_time_diff_ns(start_time, end_time);
 
+        if (et == 0)
+            return -1;
+
         // bin_idx = et / JBPF_NSECS_PER_BIN;
-        bin_idx = 63 - __builtin_clzll(et);
+        bin_idx = JBPF_NUM_HIST_BINS - 1 - __builtin_clzll(et);
         /* Any value that is spilling should go to the last bin */
         if (bin_idx >= JBPF_NUM_HIST_BINS)
             bin_idx = JBPF_NUM_HIST_BINS - 1;


### PR DESCRIPTION
This PR closes issue #101 .

It adds a check that prevents the log system to use an elapsed time of 0. It also adds a test to validate this functionality.