### PR TITLE
Add support for manual trigger and trigger workflow daily

### DIFF
--- a/.github/workflows/docker-build-and-test-arm.yaml
+++ b/.github/workflows/docker-build-and-test-arm.yaml
@@ -35,6 +35,10 @@ on:
           - test6
           - test7
 
+### daily cron job to run the workflow
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+
 env:
   ACR: jbpfpipeline
   IMAGE_TAG: ${{ github.run_id }}-${{ github.sha }}

--- a/.github/workflows/docker-build-and-test-arm.yaml
+++ b/.github/workflows/docker-build-and-test-arm.yaml
@@ -10,6 +10,31 @@ on:
       - main
       - dev
 
+  # Support workflow dispatch for manual runs
+  workflow_dispatch:
+    inputs:
+      dockerType:
+        description: 'Docker Type (e.g., mariner, ubuntu22.04, ubuntu24.04)'
+        required: true
+        default: 'mariner'
+        options:
+          - mariner
+          - ubuntu22.04
+          - ubuntu24.04
+      testCase:
+        description: 'Test Case (e.g., test0, test1, test2, test3, test4, test5, test6, test7)'
+        required: true
+        default: 'test0'
+        options:
+          - test0
+          - test1
+          - test2
+          - test3
+          - test4
+          - test5
+          - test6
+          - test7
+
 env:
   ACR: jbpfpipeline
   IMAGE_TAG: ${{ github.run_id }}-${{ github.sha }}

--- a/.github/workflows/docker_build_and_test.yaml
+++ b/.github/workflows/docker_build_and_test.yaml
@@ -35,6 +35,10 @@ on:
           - test6
           - test7
 
+### daily cron job to run the workflow
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+
 env:
   ACR: jbpfpipeline
   IMAGE_TAG: ${{ github.run_id }}-${{ github.sha }}

--- a/.github/workflows/docker_build_and_test.yaml
+++ b/.github/workflows/docker_build_and_test.yaml
@@ -10,6 +10,31 @@ on:
       - main
       - dev
 
+  # Support workflow dispatch for manual runs
+  workflow_dispatch:
+    inputs:
+      dockerType:
+        description: 'Docker Type (e.g., mariner, ubuntu22.04, ubuntu24.04)'
+        required: true
+        default: 'mariner'
+        options:
+          - mariner
+          - ubuntu22.04
+          - ubuntu24.04
+      testCase:
+        description: 'Test Case (e.g., test0, test1, test2, test3, test4, test5, test6, test7)'
+        required: true
+        default: 'test0'
+        options:
+          - test0
+          - test1
+          - test2
+          - test3
+          - test4
+          - test5
+          - test6
+          - test7
+
 env:
   ACR: jbpfpipeline
   IMAGE_TAG: ${{ github.run_id }}-${{ github.sha }}


### PR DESCRIPTION
This PR closes #112 

This PR adds manual and scheduled triggers to the Docker build and test workflows.

- Added workflow_dispatch inputs for dockerType and testCase to enable manual triggering.
- Added a daily schedule using cron to run the workflows automatically at midnight UTC.