### PR TITLE
LCM Validation when loading codeletset

### DIFF
--- a/examples/reverse_proxy/listener.cpp
+++ b/examples/reverse_proxy/listener.cpp
@@ -78,9 +78,7 @@ handle_request(http::request<Body, http::basic_fields<Allocator>>&& req, Send&& 
         read_json(is, pt);
         jbpf_codeletset_load_req load_req = {0};
 
-        std::vector<std::string> codeletset_elems;
-        codeletset_elems.push_back(address);
-        if (jbpf_reverse_proxy::parser::parse_jbpf_codeletset_load_req(pt, &load_req, codeletset_elems))
+        if (jbpf_reverse_proxy::parser::parse_jbpf_codeletset_load_req(pt, &load_req, {address}))
             return send(bad_request("Invalid JSON"));
 
         std::cout << "Loading codelet set: " << load_req.codeletset_id.name << std::endl;

--- a/examples/reverse_proxy/parser.cpp
+++ b/examples/reverse_proxy/parser.cpp
@@ -173,11 +173,11 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
         dest->runtime_threshold = runtime_threshold.get().get_value<uint32_t>();
 
     auto in_io_channel = pt.get_child_optional("in_io_channel");
-    vector<string> stream_elements_in_io_channel = codelet_elems;
-    stream_elements_in_io_channel.emplace_back(codelet_name);
-    stream_elements_in_io_channel.emplace_back(hook_name);
-    stream_elements_in_io_channel.emplace_back("input");
     if (in_io_channel) {
+        vector<string> stream_elements_in_io_channel = codelet_elems;
+        stream_elements_in_io_channel.emplace_back(codelet_name);
+        stream_elements_in_io_channel.emplace_back(hook_name);
+        stream_elements_in_io_channel.emplace_back("input");
         auto idx = 0;
         BOOST_FOREACH (const ptree::value_type& child, in_io_channel.value()) {
             if (idx >= JBPF_MAX_IO_CHANNEL) {
@@ -194,11 +194,11 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
     }
 
     auto out_io_channel = pt.get_child_optional("out_io_channel");
-    vector<string> stream_elements_out_io_channel = codelet_elems;
-    stream_elements_out_io_channel.emplace_back(codelet_name);
-    stream_elements_out_io_channel.emplace_back(hook_name);
-    stream_elements_out_io_channel.emplace_back("output");
     if (out_io_channel) {
+        vector<string> stream_elements_out_io_channel = codelet_elems;
+        stream_elements_out_io_channel.emplace_back(codelet_name);
+        stream_elements_out_io_channel.emplace_back(hook_name);
+        stream_elements_out_io_channel.emplace_back("output");
         auto idx = 0;
         BOOST_FOREACH (const ptree::value_type& child, out_io_channel.value()) {
             if (idx >= JBPF_MAX_IO_CHANNEL) {

--- a/examples/reverse_proxy/parser.cpp
+++ b/examples/reverse_proxy/parser.cpp
@@ -54,12 +54,8 @@ parse_jbpf_io_channel_desc(
         if (jbpf_lcm_cli::stream_id::from_hex(stream_id.value().get_value<string>(), &dest->stream_id))
             return JBPF_LCM_PARSE_REQ_FAILED;
     } else {
-        vector<string> map_elems;
-
-        for (auto elem : stream_elems)
-            map_elems.push_back(elem);
-
-        map_elems.push_back(name);
+        vector<string> map_elems = stream_elems;
+        map_elems.emplace_back(name);
 
         if (jbpf_lcm_cli::stream_id::generate_from_strings(map_elems, &dest->stream_id))
             return JBPF_LCM_PARSE_REQ_FAILED;

--- a/examples/reverse_proxy/parser.cpp
+++ b/examples/reverse_proxy/parser.cpp
@@ -37,7 +37,8 @@ auto_expand_environment_variables(string& text)
 }
 
 parse_req_outcome
-parse_jbpf_io_channel_desc(const ptree pt, const string path, jbpf_io_channel_desc_s* dest, vector<string> stream_elems)
+parse_jbpf_io_channel_desc(
+    const ptree pt, const string path, jbpf_io_channel_desc_s* dest, const vector<string>& stream_elems)
 {
     auto name = pt.get_child("name").get_value<string>();
     if (name.length() > JBPF_IO_CHANNEL_NAME_LEN - 1) {
@@ -112,7 +113,7 @@ parse_jbpf_linked_map_descriptor(const ptree pt, jbpf_linked_map_descriptor_s* d
 }
 
 parse_req_outcome
-parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, vector<string> codelet_elems)
+parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, const vector<string>& codelet_elems)
 {
     auto codelet_name_opt = pt.get_child_optional("codelet_name");
     if (!codelet_name_opt) {
@@ -237,7 +238,7 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
 jbpf_verify_func_t verifier_func = NULL;
 
 parse_req_outcome
-parse_jbpf_codeletset_load_req(const ptree pt, jbpf_codeletset_load_req* dest, vector<string> codeletset_elems)
+parse_jbpf_codeletset_load_req(const ptree pt, jbpf_codeletset_load_req* dest, const vector<string>& codeletset_elems)
 {
     auto name = pt.get_child("codeletset_id").get_value<string>();
     if (name.length() > JBPF_CODELETSET_NAME_LEN - 1) {

--- a/examples/reverse_proxy/parser.cpp
+++ b/examples/reverse_proxy/parser.cpp
@@ -121,7 +121,7 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
     }
     auto codelet_name = codelet_name_opt->get_value<string>();
     if (codelet_name.length() > JBPF_CODELET_NAME_LEN - 1) {
-        cout << "codelet_descriptor[].codelet_name length must be at most " << JBPF_CODELET_NAME_LEN - 1 << std::endl;
+        cout << "codelet_descriptor[].codelet_name length must be at most " << JBPF_CODELET_NAME_LEN - 1 << endl;
         return JBPF_LCM_PARSE_REQ_FAILED;
     }
     codelet_name.copy(dest->codelet_name, JBPF_CODELET_NAME_LEN - 1);
@@ -134,7 +134,7 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
     }
     auto hook_name = hook_name_opt->get_value<string>();
     if (hook_name.length() > JBPF_HOOK_NAME_LEN - 1) {
-        cout << "codelet_descriptor[].hook_name length must be at most " << JBPF_HOOK_NAME_LEN - 1 << std::endl;
+        cout << "codelet_descriptor[].hook_name length must be at most " << JBPF_HOOK_NAME_LEN - 1 << endl;
         return JBPF_LCM_PARSE_REQ_FAILED;
     }
     hook_name.copy(dest->hook_name, JBPF_HOOK_NAME_LEN - 1);
@@ -148,20 +148,20 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
     auto codelet_path = codelet_path_opt->get_value<string>();
     auto_expand_environment_variables(codelet_path);
     if (codelet_path.length() > JBPF_PATH_LEN - 1) {
-        cout << "codelet_descriptor[].codelet_path length must be at most " << JBPF_PATH_LEN - 1 << std::endl;
+        cout << "codelet_descriptor[].codelet_path length must be at most " << JBPF_PATH_LEN - 1 << endl;
         return JBPF_LCM_PARSE_REQ_FAILED;
     }
     codelet_path.copy(dest->codelet_path, JBPF_PATH_LEN - 1);
     dest->codelet_path[codelet_path.length()] = '\0';
 
     if (parser_jbpf_verifier_func == NULL) {
-        cout << "Verifier function not set" << std::endl;
+        cout << "Verifier function not set" << endl;
         return JBPF_LCM_PARSE_VERIFIER_FAILED;
     }
 
     auto result = parser_jbpf_verifier_func(codelet_path.c_str(), nullptr, nullptr);
     if (!result.verification_pass) {
-        cout << "Codelet verification failed: " << result.err_msg << std::endl;
+        cout << "Codelet verification failed: " << result.err_msg << endl;
         return JBPF_LCM_PARSE_VERIFIER_FAILED;
     }
 

--- a/examples/reverse_proxy/parser.cpp
+++ b/examples/reverse_proxy/parser.cpp
@@ -41,8 +41,7 @@ parse_jbpf_io_channel_desc(const ptree pt, const string path, jbpf_io_channel_de
 {
     auto name = pt.get_child("name").get_value<string>();
     if (name.length() > JBPF_IO_CHANNEL_NAME_LEN - 1) {
-    std:
-        cerr << "codelet_descriptor[]." << path << "[].name length must be at most " << JBPF_IO_CHANNEL_NAME_LEN - 1
+        cout << "codelet_descriptor[]." << path << "[].name length must be at most " << JBPF_IO_CHANNEL_NAME_LEN - 1
              << endl;
         return JBPF_LCM_PARSE_REQ_FAILED;
     }

--- a/examples/reverse_proxy/parser.cpp
+++ b/examples/reverse_proxy/parser.cpp
@@ -173,6 +173,10 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
         dest->runtime_threshold = runtime_threshold.get().get_value<uint32_t>();
 
     auto in_io_channel = pt.get_child_optional("in_io_channel");
+    vector<string> stream_elements_in_io_channel = codelet_elems;
+    stream_elements_in_io_channel.emplace_back(codelet_name);
+    stream_elements_in_io_channel.emplace_back(hook_name);
+    stream_elements_in_io_channel.emplace_back("input");
     if (in_io_channel) {
         auto idx = 0;
         BOOST_FOREACH (const ptree::value_type& child, in_io_channel.value()) {
@@ -180,12 +184,8 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
                 cout << "Too many in_io_channel entries (max " << JBPF_MAX_IO_CHANNEL << ")\n";
                 return JBPF_LCM_PARSE_REQ_FAILED;
             }
-            vector<string> stream_elems = codelet_elems;
-            stream_elems.push_back(codelet_name);
-            stream_elems.push_back(hook_name);
-            stream_elems.push_back("input");
-            auto ret =
-                parse_jbpf_io_channel_desc(child.second, "in_io_channel", &dest->in_io_channel[idx], stream_elems);
+            auto ret = parse_jbpf_io_channel_desc(
+                child.second, "in_io_channel", &dest->in_io_channel[idx], stream_elements_in_io_channel);
             if (ret != JBPF_LCM_PARSE_REQ_SUCCESS)
                 return ret;
             idx++;
@@ -194,6 +194,10 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
     }
 
     auto out_io_channel = pt.get_child_optional("out_io_channel");
+    vector<string> stream_elements_out_io_channel = codelet_elems;
+    stream_elements_out_io_channel.emplace_back(codelet_name);
+    stream_elements_out_io_channel.emplace_back(hook_name);
+    stream_elements_out_io_channel.emplace_back("output");
     if (out_io_channel) {
         auto idx = 0;
         BOOST_FOREACH (const ptree::value_type& child, out_io_channel.value()) {
@@ -201,12 +205,8 @@ parse_jbpf_codelet_descriptor(const ptree pt, jbpf_codelet_descriptor_s* dest, v
                 cout << "Too many out_io_channel entries (max " << JBPF_MAX_IO_CHANNEL << ")\n";
                 return JBPF_LCM_PARSE_REQ_FAILED;
             }
-            vector<string> stream_elems = codelet_elems;
-            stream_elems.push_back(codelet_name);
-            stream_elems.push_back(hook_name);
-            stream_elems.push_back("output");
-            auto ret =
-                parse_jbpf_io_channel_desc(child.second, "out_io_channel", &dest->out_io_channel[idx], stream_elems);
+            auto ret = parse_jbpf_io_channel_desc(
+                child.second, "out_io_channel", &dest->out_io_channel[idx], stream_elements_out_io_channel);
             if (ret != JBPF_LCM_PARSE_REQ_SUCCESS)
                 return ret;
             idx++;

--- a/examples/reverse_proxy/parser.hpp
+++ b/examples/reverse_proxy/parser.hpp
@@ -24,7 +24,9 @@ parser_jbpf_set_verify_func(jbpf_verify_func_t func);
 
 parse_req_outcome
 parse_jbpf_codeletset_load_req(
-    const boost::property_tree::ptree pt, jbpf_codeletset_load_req* dest, std::vector<std::string> codeletset_elems);
+    const boost::property_tree::ptree pt,
+    jbpf_codeletset_load_req* dest,
+    const std::vector<std::string>& codeletset_elems);
 parse_req_outcome
 parse_jbpf_codeletset_unload_req(const boost::property_tree::ptree pt, jbpf_codeletset_unload_req* dest);
 std::string

--- a/jbpf_tests/functional/request_validation/codelet_LinkedMaps_maxExceeded.c
+++ b/jbpf_tests/functional/request_validation/codelet_LinkedMaps_maxExceeded.c
@@ -132,6 +132,7 @@ main(int argc, char** argv)
 
     // Load the codeletset
     assert(jbpf_codeletset_load(&codeletset_req_c1, &err_msg) == JBPF_CODELET_PARAM_INVALID);
+    assert(strlen(err_msg.err_msg) > 0);
 
     // Stop
     jbpf_stop();

--- a/tools/lcm_cli/loader.cpp
+++ b/tools/lcm_cli/loader.cpp
@@ -130,9 +130,7 @@ parseArgs(int ac, char** av, lcm_cli_config* opts)
     jbpf_lcm_cli::parser::parse_req_outcome parse_ret;
     switch ((*opts).typ) {
     case load: {
-        vector<string> codeletset_elems;
-        codeletset_elems.push_back(address);
-        parse_ret = jbpf_lcm_cli::parser::parse_jbpf_codeletset_load_req(cfg, &(*opts).req.load, codeletset_elems);
+        parse_ret = jbpf_lcm_cli::parser::parse_jbpf_codeletset_load_req(cfg, &(*opts).req.load, {address});
         break;
     }
 

--- a/tools/lcm_cli/parser.cpp
+++ b/tools/lcm_cli/parser.cpp
@@ -109,8 +109,10 @@ parse_req_outcome
 parse_jbpf_codelet_descriptor(YAML::Node cfg, jbpf_codelet_descriptor_s* dest, const vector<string>& codelet_elems)
 {
     if (!cfg.IsDefined() || !cfg["codelet_name"].IsDefined() || !cfg["hook_name"].IsDefined() ||
-        !cfg["codelet_path"].IsDefined())
+        !cfg["codelet_path"].IsDefined()) {
+        cout << "Missing required fields: codelet_name, hook_name, or codelet_path\n";
         return JBPF_LCM_PARSE_REQ_FAILED;
+    }
 
     auto codelet_name = cfg["codelet_name"].as<string>();
     if (codelet_name.length() > JBPF_CODELET_NAME_LEN - 1) {

--- a/tools/lcm_cli/parser.cpp
+++ b/tools/lcm_cli/parser.cpp
@@ -161,6 +161,11 @@ parse_jbpf_codelet_descriptor(YAML::Node cfg, jbpf_codelet_descriptor_s* dest, c
         }
 
         dest->num_in_io_channel = cfg["in_io_channel"].size();
+        if (dest->num_in_io_channel > JBPF_MAX_IO_CHANNEL) {
+            cout << "codelet_descriptor[].in_io_channel exceeds maximum number of input channels: "
+                 << JBPF_MAX_IO_CHANNEL << endl;
+            return JBPF_LCM_PARSE_REQ_FAILED;
+        }
         vector<string> stream_elems_in = codelet_elems;
         stream_elems_in.emplace_back(codelet_name);
         stream_elems_in.emplace_back(hook_name);
@@ -181,6 +186,11 @@ parse_jbpf_codelet_descriptor(YAML::Node cfg, jbpf_codelet_descriptor_s* dest, c
         }
 
         dest->num_out_io_channel = cfg["out_io_channel"].size();
+        if (dest->num_out_io_channel > JBPF_MAX_IO_CHANNEL) {
+            cout << "codelet_descriptor[].out_io_channel exceeds maximum number of output channels: "
+                 << JBPF_MAX_IO_CHANNEL << endl;
+            return JBPF_LCM_PARSE_REQ_FAILED;
+        }
         vector<string> stream_elems_out = codelet_elems;
         stream_elems_out.emplace_back(codelet_name);
         stream_elems_out.emplace_back(hook_name);

--- a/tools/lcm_cli/parser.cpp
+++ b/tools/lcm_cli/parser.cpp
@@ -26,7 +26,8 @@ auto_expand_environment_variables(string& text)
 }
 
 parse_req_outcome
-parse_jbpf_io_channel_desc(YAML::Node cfg, const string path, jbpf_io_channel_desc_s* dest, vector<string> stream_elems)
+parse_jbpf_io_channel_desc(
+    YAML::Node cfg, const string path, jbpf_io_channel_desc_s* dest, const vector<string>& stream_elems)
 {
     if (!cfg.IsDefined() || !cfg["name"].IsDefined())
         return JBPF_LCM_PARSE_REQ_FAILED;
@@ -105,7 +106,7 @@ parse_jbpf_linked_map_descriptor(YAML::Node cfg, jbpf_linked_map_descriptor_s* d
 }
 
 parse_req_outcome
-parse_jbpf_codelet_descriptor(YAML::Node cfg, jbpf_codelet_descriptor_s* dest, vector<string> codelet_elems)
+parse_jbpf_codelet_descriptor(YAML::Node cfg, jbpf_codelet_descriptor_s* dest, const vector<string>& codelet_elems)
 {
     if (!cfg.IsDefined() || !cfg["codelet_name"].IsDefined() || !cfg["hook_name"].IsDefined() ||
         !cfg["codelet_path"].IsDefined())
@@ -210,7 +211,7 @@ parse_jbpf_codelet_descriptor(YAML::Node cfg, jbpf_codelet_descriptor_s* dest, v
 } // namespace internal
 
 parse_req_outcome
-parse_jbpf_codeletset_load_req(YAML::Node cfg, jbpf_codeletset_load_req* dest, vector<string> codeletset_elems)
+parse_jbpf_codeletset_load_req(YAML::Node cfg, jbpf_codeletset_load_req* dest, const vector<string>& codeletset_elems)
 {
     // Validate presence and types of required YAML fields
     if (!cfg.IsDefined() || !cfg["codeletset_id"].IsDefined() || !cfg["codelet_descriptor"].IsDefined() ||

--- a/tools/lcm_cli/parser.hpp
+++ b/tools/lcm_cli/parser.hpp
@@ -20,7 +20,7 @@ enum parse_req_outcome
 
 parse_req_outcome
 parse_jbpf_codeletset_load_req(
-    YAML::Node cfg, jbpf_codeletset_load_req* dest, std::vector<std::string> codeletset_elems);
+    YAML::Node cfg, jbpf_codeletset_load_req* dest, const std::vector<std::string>& codeletset_elems);
 parse_req_outcome
 parse_jbpf_codeletset_unload_req(YAML::Node cfg, jbpf_codeletset_unload_req* dest);
 std::string


### PR DESCRIPTION
When loading a codeletset via LCM, the validations of codeletset are not checked. This PR enforces the checks of the following, and reject the requests if any violates.

- JBPF_MAX_LINKED_MAPS
- JBPF_MAX_IO_CHANNEL
- JBPF_MAX_CODELETS_IN_CODELETSET

This PR also moves the vector outside the loop as it is not changed in each loop and addresses a few code issues (related to performance)

## Testing
we only have a limited test in jbpf i.e. [jbpf_e2e_lcm_ipc_standalone_test](https://github.com/microsoft/jbpf/blob/main/jbpf_tests/e2e_examples/jbpf_e2e_lcm_ipc_standalone_test.c) however, manual tests have been done using JRTC (integration tests) on this.