### PR TITLE
Fix jbpf_io_ipc_test to explicitly fail when serde libraries cannot be loaded

### DIFF
--- a/jbpf_tests/functional/io/jbpf_io_ipc_test.c
+++ b/jbpf_tests/functional/io/jbpf_io_ipc_test.c
@@ -76,6 +76,11 @@ struct jbpf_io_stream_id local_stream_id = {
 unsigned char*
 read_serde_lib(const char* filename, long* filesize)
 {
+    if (filename == NULL) {
+        fprintf(stderr, "Error: serde library path is NULL\n");
+        return NULL;
+    }
+
     FILE* file = fopen(filename, "rb"); // Open the file in binary read mode
     if (file == NULL) {
         perror("Failed to open file");
@@ -303,6 +308,13 @@ run_secondary(char* serde1, char* serde2)
 
     serde_lib = read_serde_lib(serde1, &lib_size);
     serde2_lib = read_serde_lib(serde2, &lib2_size);
+
+    // The test requires valid serde libraries to be provided
+    // If NULL was returned, report failure explicitly
+    if (serde_lib == NULL || serde2_lib == NULL) {
+        fprintf(stderr, "Error: Failed to load serde libraries\n");
+        exit(EXIT_FAILURE);
+    }
 
     // Create an output channel
     io_channel = jbpf_io_create_channel(


### PR DESCRIPTION
## Summary

When serde and serde2.so are not given (NULL), the test currently passes despite showing error messages:
- **Failed to open file: (null)**
- **Failed to open file: JBPF_PATH=/jbpf**

This PR fixes the issue by:

1. **Adding NULL check in read_serde_lib()**: Instead of silently passing NULL to fopen, we now emit a clear error message:  and return NULL immediately.

2. **Adding explicit failure when libraries can't be loaded**: After calling , if either  or  is NULL, the test now calls  explicitly instead of continuing and causing confusing downstream errors.

## Changes

- :
  - Added NULL check at start of  function
  - Added explicit  when serde libraries fail to load

## Testing

The fix makes the test behavior match the error output - when required libraries are not provided, the test exits with failure instead of silently proceeding.

Fixes microsoft/jbpf#54