### PR TITLE
Fail jbpf_io_ipc_test when serde arguments are missing

### DIFF
--- a/jbpf_tests/functional/io/CMakeLists.txt
+++ b/jbpf_tests/functional/io/CMakeLists.txt
@@ -18,6 +18,11 @@ foreach(TEST_FILE ${IO_TESTS_SOURCES})
   # Add the test to the list of tests to be executed
   add_test(NAME io/${TEST_NAME} COMMAND ${TEST_NAME} $<TARGET_FILE:jbpf::test_serde> $<TARGET_FILE:jbpf::test_serde2> ${RUNTIME_OUTPUT_DIRECTORY})
 
+  if(TEST_NAME STREQUAL "jbpf_io_ipc_test")
+    add_test(NAME io/${TEST_NAME}_missing_serde COMMAND ${TEST_NAME})
+    set_tests_properties(io/${TEST_NAME}_missing_serde PROPERTIES WILL_FAIL TRUE)
+  endif()
+
   # Test coverage
   list(APPEND JBPF_TESTS io/${TEST_NAME})
   add_clang_format_check(${TEST_NAME} ${TEST_FILE})

--- a/jbpf_tests/functional/io/jbpf_io_ipc_test.c
+++ b/jbpf_tests/functional/io/jbpf_io_ipc_test.c
@@ -470,6 +470,10 @@ run_secondary(char* serde1, char* serde2)
 int
 main(int argc, char* argv[])
 {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <serde-lib> <serde2-lib>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
 
     pid_t child_pid;
     int secondary_status;


### PR DESCRIPTION
## Summary

Validate the two required serde-library arguments before the IPC test accesses `argv[1]` and `argv[2]`. Invoking the binary without them now prints a concise usage message and exits with failure. A CTest negative case locks in that behavior.

Fixes #54.

## Validation

- added a CTest negative case for an invocation without serde arguments
- `git diff --check`

AI assistance: this implementation was prepared with AI-assisted tooling. The focused checks listed above were run on the submitted commit.
